### PR TITLE
skiplist: add generic version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
     - name: Go vet
       run: make vet
     - name: Test

--- a/_examples/skiplist.go
+++ b/_examples/skiplist.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 
-	skipListMap := skiplist.NewSkipListMap(skiplist.IntComparator)
+	skipListMap := skiplist.NewSkipListMap[int, int](skiplist.OrderedComparator[int]{})
 	skipListMap.Insert(13, 91)
 	skipListMap.Insert(3, 1)
 	skipListMap.Insert(5, 2)

--- a/_examples/sstables.go
+++ b/_examples/sstables.go
@@ -20,7 +20,7 @@ func main() {
 func mainSimpleRead(path string) {
 	reader, err := sstables.NewSSTableReader(
 		sstables.ReadBasePath("/tmp/sstable_example/"),
-		sstables.ReadWithKeyComparator(skiplist.BytesComparator))
+		sstables.ReadWithKeyComparator(skiplist.BytesComparator{}))
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -55,12 +55,12 @@ func mainSimpleRead(path string) {
 func mainWriteSimple(path string) {
 	writer, err := sstables.NewSSTableSimpleWriter(
 		sstables.WriteBasePath(path),
-		sstables.WithKeyComparator(skiplist.BytesComparator))
+		sstables.WithKeyComparator(skiplist.BytesComparator{}))
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
 
-	skipListMap := skiplist.NewSkipListMap(skiplist.BytesComparator)
+	skipListMap := skiplist.NewSkipListMap[[]byte, []byte](skiplist.BytesComparator{})
 	skipListMap.Insert([]byte{1}, []byte{1})
 	skipListMap.Insert([]byte{2}, []byte{2})
 	skipListMap.Insert([]byte{3}, []byte{3})
@@ -78,7 +78,7 @@ func mainWriteStreaming() {
 
 	writer, err := sstables.NewSSTableStreamWriter(
 		sstables.WriteBasePath(path),
-		sstables.WithKeyComparator(skiplist.BytesComparator))
+		sstables.WithKeyComparator(skiplist.BytesComparator{}))
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}

--- a/benchmark/sstable_read_test.go
+++ b/benchmark/sstable_read_test.go
@@ -16,7 +16,7 @@ func BenchmarkSSTableRead(b *testing.B) {
 	assert.Nil(b, err)
 	defer func() { assert.Nil(b, os.RemoveAll(tmpDir)) }()
 
-	cmp := skiplist.BytesComparator
+	cmp := skiplist.BytesComparator{}
 	writer, err := sstables.NewSSTableStreamWriter(sstables.WriteBasePath(tmpDir), sstables.WithKeyComparator(cmp))
 	assert.Nil(b, err)
 	assert.Nil(b, writer.Open())
@@ -32,7 +32,7 @@ func BenchmarkSSTableRead(b *testing.B) {
 	fullScanTable(b, tmpDir, cmp)
 }
 
-func fullScanTable(b *testing.B, tmpDir string, cmp skiplist.KeyComparator) {
+func fullScanTable(b *testing.B, tmpDir string, cmp skiplist.Comparator[[]byte]) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		reader, err := sstables.NewSSTableReader(sstables.ReadBasePath(tmpDir), sstables.ReadWithKeyComparator(cmp))

--- a/benchmark/sstable_write_test.go
+++ b/benchmark/sstable_write_test.go
@@ -25,7 +25,7 @@ func BenchmarkSSTableMemstoreFlush(b *testing.B) {
 		{"2048mb", 1024 * 1024 * 1024 * 2},
 	}
 
-	cmp := skiplist.BytesComparator
+	cmp := skiplist.BytesComparator{}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			mStore := memstore.NewMemStore()

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
-go 1.17
+go 1.18

--- a/memstore/memstore_sstable_iterator.go
+++ b/memstore/memstore_sstable_iterator.go
@@ -6,7 +6,7 @@ import (
 )
 
 type SkipListSStableIterator struct {
-	iterator skiplist.SkipListIteratorI
+	iterator skiplist.IteratorI[[]byte, ValueStruct]
 }
 
 func (s SkipListSStableIterator) Next() ([]byte, []byte, error) {
@@ -18,6 +18,5 @@ func (s SkipListSStableIterator) Next() ([]byte, []byte, error) {
 			return nil, nil, err
 		}
 	}
-	valStruct := val.(ValueStruct)
-	return key.([]byte), *valStruct.value, nil
+	return key, *val.value, nil
 }

--- a/memstore/memstore_test.go
+++ b/memstore/memstore_test.go
@@ -57,7 +57,7 @@ func TestMemStoreUpsertUpdatesOnExist(t *testing.T) {
 	// make sure the value is set correctly
 	kv, err := m.skipListMap.Get([]byte("a"))
 	assert.Nil(t, err)
-	assert.Equal(t, []byte("aVal"), *kv.(ValueStruct).value)
+	assert.Equal(t, []byte("aVal"), *kv.value)
 
 	err = m.Upsert([]byte("a"), []byte("aVal2"))
 	assert.Nil(t, err)
@@ -65,7 +65,7 @@ func TestMemStoreUpsertUpdatesOnExist(t *testing.T) {
 	// make sure that the value was changed under the hood
 	kv, err = m.skipListMap.Get([]byte("a"))
 	assert.Nil(t, err)
-	assert.Equal(t, []byte("aVal2"), *kv.(ValueStruct).value)
+	assert.Equal(t, []byte("aVal2"), *kv.value)
 }
 
 func TestMemStoreDeleteTombstones(t *testing.T) {
@@ -76,7 +76,7 @@ func TestMemStoreDeleteTombstones(t *testing.T) {
 	// make sure the value is set correctly
 	kv, err := m.skipListMap.Get([]byte("a"))
 	assert.Nil(t, err)
-	assert.Equal(t, []byte("aVal"), *kv.(ValueStruct).value)
+	assert.Equal(t, []byte("aVal"), *kv.value)
 
 	err = m.Delete([]byte("a"))
 	assert.False(t, m.Contains([]byte("a")))
@@ -85,7 +85,7 @@ func TestMemStoreDeleteTombstones(t *testing.T) {
 	assert.Nil(t, err)
 
 	// make sure that Get will return the new error message
-	assert.Nil(t, *kv.(ValueStruct).value)
+	assert.Nil(t, *kv.value)
 	_, err = m.Get([]byte("a"))
 	assert.Equal(t, KeyTombstoned, err)
 }
@@ -107,7 +107,7 @@ func TestMemStoreAddTombStonedKeyAgain(t *testing.T) {
 	assert.Equal(t, 1, m.Size())
 	kv, err := m.skipListMap.Get([]byte("a"))
 	assert.Nil(t, err)
-	assert.Equal(t, []byte("aVal2"), *kv.(ValueStruct).value)
+	assert.Equal(t, []byte("aVal2"), *kv.value)
 }
 
 func TestMemStoreDeleteSemantics(t *testing.T) {
@@ -131,7 +131,7 @@ func TestMemStoreDeleteSemantics(t *testing.T) {
 	// make sure that the value was changed under the hood
 	kv, err := m.skipListMap.Get(keyA)
 	assert.Nil(t, err)
-	assert.Nil(t, *kv.(ValueStruct).value)
+	assert.Nil(t, *kv.value)
 }
 
 func TestMemStoreSizeEstimates(t *testing.T) {
@@ -297,7 +297,7 @@ func TestMemStoreSStableIteratorWithTombstones(t *testing.T) {
 		actualKey, actualValue, err := it.Next()
 		assert.Nil(t, err)
 		assert.Equal(t, e+"key", string(actualKey))
-		// on tombstones we expect the key to be returned, but the value being nil
+		// on tombstones, we expect the key to be returned, but the value being nil
 		if e == "b" {
 			assert.Nil(t, actualValue)
 		} else {

--- a/simpledb/compaction.go
+++ b/simpledb/compaction.go
@@ -73,7 +73,7 @@ func executeCompaction(db *DB) (*proto.CompactionMetadata, error) {
 
 	writer, err := sstables.NewSSTableStreamWriter(
 		sstables.WriteBasePath(writeFolder),
-		sstables.WithKeyComparator(skiplist.BytesComparator),
+		sstables.WithKeyComparator(skiplist.BytesComparator{}),
 		sstables.BloomExpectedNumberOfElements(numRecords))
 	if err != nil {
 		return nil, err

--- a/simpledb/db.go
+++ b/simpledb/db.go
@@ -65,7 +65,7 @@ type DB struct {
 	// read more here: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	currentGeneration uint64
 
-	cmp                   skiplist.KeyComparator
+	cmp                   skiplist.Comparator[[]byte]
 	basePath              string
 	currentSSTablePath    string
 	memstoreMaxSize       uint64
@@ -341,7 +341,7 @@ func NewSimpleDB(basePath string, extraOptions ...ExtraOption) (*DB, error) {
 		extraOption(extraOpts)
 	}
 
-	cmp := skiplist.BytesComparator
+	cmp := skiplist.BytesComparator{}
 	mStore := memstore.NewMemStore()
 	rwLock := &sync.RWMutex{}
 	flusherChan := make(chan memStoreFlushAction)

--- a/simpledb/flush_test.go
+++ b/simpledb/flush_test.go
@@ -34,11 +34,11 @@ func TestFlushHappyPath(t *testing.T) {
 	}
 
 	db := &DB{
-		cmp:               skiplist.BytesComparator,
+		cmp:               skiplist.BytesComparator{},
 		basePath:          tmpDir,
 		currentGeneration: 42,
 		rwLock:            &sync.RWMutex{},
-		sstableManager:    NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, tmpDir),
+		sstableManager:    NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, tmpDir),
 	}
 	err = executeFlush(db, action)
 	assert.Nil(t, err)

--- a/simpledb/sstable_manager.go
+++ b/simpledb/sstable_manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 type SSTableManager struct {
-	cmp               skiplist.KeyComparator
+	cmp               skiplist.Comparator[[]byte]
 	databaseLock      *sync.RWMutex
 	basePath          string
 	managerLock       *sync.RWMutex
@@ -134,7 +134,7 @@ func (s *SSTableManager) candidateTablesForCompaction(compactionMaxSizeBytes uin
 	}
 }
 
-func NewSSTableManager(cmp skiplist.KeyComparator, dbLock *sync.RWMutex, basePath string) *SSTableManager {
+func NewSSTableManager(cmp skiplist.Comparator[[]byte], dbLock *sync.RWMutex, basePath string) *SSTableManager {
 	return &SSTableManager{
 		cmp:           cmp,
 		managerLock:   &sync.RWMutex{},

--- a/simpledb/sstable_manager_test.go
+++ b/simpledb/sstable_manager_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestSSTableManagerAdditionHappyPath(t *testing.T) {
-	manager := NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, "")
+	manager := NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, "")
 
 	assert.Equal(t, 0, len(manager.allSSTableReaders))
 	manager.addReader(sstables.EmptySStableReader{})
@@ -25,14 +25,14 @@ func TestSSTableManagerAdditionHappyPath(t *testing.T) {
 }
 
 func TestSSTableInitialStateWillReturnSSTable(t *testing.T) {
-	manager := NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, "")
+	manager := NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, "")
 	assert.Equal(t, reflect.TypeOf(sstables.EmptySStableReader{}), reflect.TypeOf(manager.currentSSTable()))
 	_, err := manager.currentSSTable().Get([]byte{1, 2, 3})
 	assert.Equal(t, sstables.NotFound, err)
 }
 
 func TestSSTableManagerClearingReaders(t *testing.T) {
-	manager := NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, "")
+	manager := NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, "")
 
 	assert.Equal(t, 0, len(manager.allSSTableReaders))
 	manager.addReader(sstables.EmptySStableReader{})
@@ -46,7 +46,7 @@ func TestSSTableManagerClearingReaders(t *testing.T) {
 }
 
 func TestSSTableManagerSelectCompactionCandidates(t *testing.T) {
-	manager := NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, "")
+	manager := NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, "")
 
 	manager.addReader(&MockSSTableReader{
 		metadata: &proto.MetaData{NumRecords: 10, TotalBytes: 100},
@@ -80,9 +80,9 @@ func TestSSTableCompactionReflectionHappyPath(t *testing.T) {
 	// that's our fake compaction path that actually must exist for the logic to work properly
 	const compactionOutputPath = "4"
 	assert.Nil(t, os.MkdirAll(filepath.Join(dir, compactionOutputPath), 0700))
-	writeSSTableInDatabaseFolder(t, &DB{cmp: skiplist.BytesComparator, basePath: dir}, compactionOutputPath)
+	writeSSTableInDatabaseFolder(t, &DB{cmp: skiplist.BytesComparator{}, basePath: dir}, compactionOutputPath)
 
-	manager := NewSSTableManager(skiplist.BytesComparator, &sync.RWMutex{}, dir)
+	manager := NewSSTableManager(skiplist.BytesComparator{}, &sync.RWMutex{}, dir)
 	manager.addReader(&MockSSTableReader{metadata: &proto.MetaData{}, path: "1"})
 	manager.addReader(&MockSSTableReader{metadata: &proto.MetaData{}, path: "2"})
 	manager.addReader(&MockSSTableReader{metadata: &proto.MetaData{}, path: "3"})

--- a/skiplist/README.md
+++ b/skiplist/README.md
@@ -1,7 +1,61 @@
-## Using SkipListMap
+# SkipLists
 
-Whenever you find yourself in need of a sorted list/map for range scans or ordered iteration, you can resort to a `SkipList`. 
-The `SkipListMap` in this project is based on [LevelDBs skiplist](https://github.com/google/leveldb/blob/master/db/skiplist.h) and super easy to use:
+Whenever you find yourself in need of a sorted list/map for range scans or ordered iteration, you can resort to a `SkipList`. The `SkipList` in this project is based on [LevelDBs skiplist](https://github.com/google/leveldb/blob/master/db/skiplist.h)
+
+This package is the only one compatible with versions pre-generics.
+
+## Using skiplist.Map (generics Go >=1.18)
+
+You can get the full example from [examples/skiplist.go](/_examples/skiplist.go).
+
+```go
+import (
+	"github.com/thomasjungblut/go-sstables/skiplist"
+	"log"
+)
+
+func main() {
+
+	skipListMap := skiplist.NewSkipListMap[int, int](skiplist.OrderedComparator[int]{})
+	skipListMap.Insert(13, 91)
+	skipListMap.Insert(3, 1)
+	skipListMap.Insert(5, 2)
+	log.Printf("size: %d", skipListMap.Size())
+
+	it, _ := skipListMap.Iterator()
+	for {
+		k, v, err := it.Next()
+		if err == skiplist.Done {
+			break
+		}
+		log.Printf("key: %d, value: %d", k, v)
+	}
+
+	log.Printf("starting at key: %d", 5)
+	it, _ = skipListMap.IteratorStartingAt(5)
+	for {
+		k, v, err := it.Next()
+		if err == skiplist.Done {
+			break
+		}
+		log.Printf("key: %d, value: %d", k, v)
+	}
+
+	log.Printf("between: %d and %d", 8, 50)
+	it, _ = skipListMap.IteratorBetween(8, 50)
+	for {
+		k, v, err := it.Next()
+		if err == skiplist.Done {
+			break
+		}
+		log.Printf("key: %d, value: %d", k, v)
+	}
+}
+```
+
+## Using SkipListMap (pre-generics Go <1.18)
+
+Here's an example on how to use it with versions lower than Go 1.18:
 
 ```go
 skipListMap := skiplist.NewSkipListMap(skiplist.IntComparator)
@@ -38,8 +92,8 @@ for {
     }
     log.Printf("key: %d, value: %d", k, v)
 }
+
 ```
 
-You can supply any kind of element and comparator to sort arbitrary structs and primitives. 
-You can get the full example from [examples/skiplist.go](/_examples/skiplist.go).
- 
+You can supply any kind of element and comparator to sort arbitrary structs and primitives.
+

--- a/skiplist/map_generic.go
+++ b/skiplist/map_generic.go
@@ -1,0 +1,258 @@
+//go:build go1.18
+// +build go1.18
+
+// Package skiplist is a translation from LevelDBs skiplist (https://github.com/google/leveldb/blob/master/db/skiplist.h)
+package skiplist
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+)
+
+type Comparator[T any] interface {
+	// Compare contract (similar to Java):
+	// < 0 when a < b
+	// == 0 when a == b
+	// > 0 when a > b
+	Compare(a T, b T) int
+}
+
+// Done indicates an iterator has returned all items.
+// https://github.com/GoogleCloudPlatform/google-cloud-go/wiki/Iterator-Guidelines
+var Done = errors.New("no more items in iterator")
+var NotFound = errors.New("key was not found")
+
+// Ordered represents the set of types for which the '<' and '>' operator work.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64 | string
+}
+
+type OrderedComparator[T Ordered] struct {
+}
+
+func (OrderedComparator[T]) Compare(a T, b T) int {
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+	return 0
+}
+
+type BytesComparator struct {
+}
+
+func (BytesComparator) Compare(a []byte, b []byte) int {
+	return bytes.Compare(a, b)
+}
+
+type IteratorI[K any, V any] interface {
+	// Next returns the next key, value in sequence
+	// returns Done as the error when the iterator is exhausted
+	Next() (K, V, error)
+}
+
+type Iterator[K any, V any] struct {
+	comp      Comparator[K]
+	node      *Node[K, V]
+	keyHigher *K
+	doneNext  bool
+}
+
+func (it *Iterator[K, V]) Next() (_ K, _ V, done error) {
+	done = Done
+	if it.node == nil || it.doneNext {
+		return
+	}
+	cur := it.node
+	it.node = it.node.Next(0)
+
+	if it.keyHigher != nil {
+		c := it.comp.Compare(cur.key, *it.keyHigher)
+		if c == 0 {
+			// we have reached the higher end of the range, and we return it, next iteration stops
+			it.doneNext = true
+		} else if c > 0 { // we're over the higher end of the range already, return immediately
+			return
+		}
+	}
+
+	return cur.key, cur.value, nil
+}
+
+type MapI[K any, V any] interface {
+	Size() int
+
+	// Insert key/value into the list.
+	// REQUIRES: nothing that compares equal to key is currently in the list.
+	Insert(key K, value V)
+
+	// Contains returns true if an entry that compares equal to key is in the list.
+	Contains(key K) bool
+
+	// Get returns the value element that compares equal to the key supplied or returns NotFound if it does not exist.
+	Get(key K) (V, error)
+
+	// Iterator returns an iterator over the whole sorted sequence
+	Iterator() (IteratorI[K, V], error)
+
+	// IteratorStartingAt returns an iterator over the sorted sequence starting at the given key (inclusive if key is in the list).
+	// Using a key that is out of the sequence range will result in either an empty iterator or the full sequence.
+	IteratorStartingAt(key K) (IteratorI[K, V], error)
+
+	// IteratorBetween Returns an iterator over the sorted sequence starting at the given keyLower (inclusive if key is in the list)
+	// and until the given keyHigher was reached (inclusive if key is in the list).
+	// Using keys that are out of the sequence range will result in either an empty iterator or the full sequence.
+	// If keyHigher is lower than keyLower an error will be returned
+	IteratorBetween(keyLower K, keyHigher K) (IteratorI[K, V], error)
+}
+
+type NodeI[K any, V any] interface {
+	Next(height int) *Node[K, V]
+	SetNext(height int, node *Node[K, V])
+}
+
+type Node[K any, V any] struct {
+	key   K
+	value V
+	// array length is equal to the current node's height, next[0] is the lowest level pointer
+	next []*Node[K, V]
+}
+
+func (n *Node[K, V]) Next(height int) *Node[K, V] {
+	return n.next[height]
+}
+
+func (n *Node[K, V]) SetNext(height int, node *Node[K, V]) {
+	n.next[height] = node
+}
+
+func newSkipListNode[K any, V any](key K, value V, maxHeight int) *Node[K, V] {
+	nextNodes := make([]*Node[K, V], maxHeight)
+	return &Node[K, V]{key: key, value: value, next: nextNodes}
+}
+
+func newDefaultSkipListNode[K any, V any](maxHeight int) *Node[K, V] {
+	nextNodes := make([]*Node[K, V], maxHeight)
+	return &Node[K, V]{next: nextNodes}
+}
+
+type Map[K any, V any] struct {
+	maxHeight int
+	size      int
+
+	comp Comparator[K]
+	head *Node[K, V]
+}
+
+func (list *Map[K, V]) Insert(key K, value V) {
+	prevTable := make([]*Node[K, V], list.maxHeight)
+	x := findGreaterOrEqual(list, key, prevTable)
+
+	// we don't allow dupes in this data structure
+	if x != nil && list.comp.Compare(key, x.key) == 0 {
+		panic("duplicate key insertions are not allowed")
+	}
+
+	randomHeight := randomHeight(list.maxHeight)
+	// do a re-balancing if we have reached new heights
+	if randomHeight > list.maxHeight {
+		for i := list.maxHeight; i < randomHeight; i++ {
+			prevTable[i] = list.head
+		}
+		list.maxHeight = randomHeight
+	}
+
+	x = newSkipListNode(key, value, randomHeight)
+	for i := 0; i < randomHeight; i++ {
+		x.SetNext(i, prevTable[i].Next(i))
+		prevTable[i].SetNext(i, x)
+	}
+
+	list.size++
+}
+
+func (list *Map[K, V]) Size() int {
+	return list.size
+}
+
+func (list *Map[K, V]) Contains(key K) bool {
+	_, err := list.Get(key)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func (list *Map[K, V]) Get(key K) (_ V, err error) {
+	err = NotFound
+
+	x := findGreaterOrEqual(list, key, nil)
+	if x != nil && list.comp.Compare(key, x.key) == 0 {
+		return x.value, nil
+	}
+
+	return
+}
+
+func (list *Map[K, V]) Iterator() (IteratorI[K, V], error) {
+	// we start the iterator at the next node from the head, so we can share it with the range scan below
+	return &Iterator[K, V]{node: list.head.Next(0), comp: list.comp, keyHigher: nil}, nil
+}
+
+func (list *Map[K, V]) IteratorStartingAt(key K) (IteratorI[K, V], error) {
+	node := findGreaterOrEqual(list, key, nil)
+	return &Iterator[K, V]{node: node, comp: list.comp, keyHigher: nil}, nil
+}
+
+func (list *Map[K, V]) IteratorBetween(keyLower K, keyHigher K) (IteratorI[K, V], error) {
+	node := findGreaterOrEqual(list, keyLower, nil)
+	if list.comp.Compare(keyLower, keyHigher) > 0 {
+		return nil, errors.New("keyHigher is lower than keyLower")
+	}
+	return &Iterator[K, V]{node: node, comp: list.comp, keyHigher: &keyHigher}, nil
+}
+
+func NewSkipListMap[K any, V any](comp Comparator[K]) MapI[K, V] {
+	const maxHeight = 12
+	return &Map[K, V]{head: newDefaultSkipListNode[K, V](maxHeight), comp: comp, maxHeight: maxHeight}
+}
+
+func findGreaterOrEqual[K any, V any](list *Map[K, V], key K, prevTable []*Node[K, V]) *Node[K, V] {
+	x := list.head
+	level := list.maxHeight - 1
+	for {
+		next := x.Next(level)
+		// check if this key is after the next node
+		if next != nil && list.comp.Compare(key, next.key) > 0 {
+			// keep searching in this list
+			x = next
+		} else {
+			if prevTable != nil {
+				prevTable[level] = x
+			}
+
+			if level == 0 {
+				return next
+			} else {
+				// Switch to next list
+				level--
+			}
+		}
+	}
+}
+
+func randomHeight(maxHeight int) int {
+	const branchFactor = 4
+	height := 1
+	for height < maxHeight && ((rand.Int() % branchFactor) == 0) {
+		height++
+	}
+
+	if height <= 0 || height > maxHeight {
+		panic("height was invalid")
+	}
+
+	return height
+}

--- a/skiplist/skip_list_map.go
+++ b/skiplist/skip_list_map.go
@@ -1,4 +1,6 @@
-// basically a translation from LevelDBs skiplist (https://github.com/google/leveldb/blob/master/db/skiplist.h)
+//go:build !go1.18
+// +build !go1.18
+
 package skiplist
 
 import (

--- a/sstables/README.md
+++ b/sstables/README.md
@@ -21,7 +21,7 @@ defer os.RemoveAll(path)
 
 writer, err := sstables.NewSSTableStreamWriter(
     sstables.WriteBasePath(path),
-    sstables.WithKeyComparator(skiplist.BytesComparator))
+    sstables.WithKeyComparator(skiplist.BytesComparator{}))
 if err != nil { log.Fatalf("error: %v", err) }
 
 err = writer.Open()
@@ -48,10 +48,10 @@ defer os.RemoveAll(path)
 
 writer, err := sstables.NewSSTableSimpleWriter(
     sstables.WriteBasePath(path),
-    sstables.WithKeyComparator(skiplist.BytesComparator))
+    sstables.WithKeyComparator(skiplist.BytesComparator{}))
 if err != nil { log.Fatalf("error: %v", err) }
 
-skipListMap := skiplist.NewSkipListMap(skiplist.BytesComparator)
+skipListMap := skiplist.NewSkipListMap(skiplist.BytesComparator{})
 skipListMap.Insert([]byte{1}, []byte{1})
 skipListMap.Insert([]byte{2}, []byte{2})
 skipListMap.Insert([]byte{3}, []byte{3})
@@ -68,7 +68,7 @@ Below example will show what metadata is available, how to get values and check 
 ```go
 reader, err := sstables.NewSSTableReader(
     sstables.ReadBasePath("/tmp/sstable_example/"),
-    sstables.ReadWithKeyComparator(skiplist.BytesComparator))
+    sstables.ReadWithKeyComparator(skiplist.BytesComparator{}))
 if err != nil { log.Fatalf("error: %v", err) }
 defer reader.Close()
 
@@ -108,7 +108,7 @@ var iteratorContext []inteface{}
 for i := 0; i < numFiles; i++ {
     reader, err := NewSSTableReader(
             ReadBasePath(sstablePath),
-            ReadWithKeyComparator(skiplist.BytesComparator))
+            ReadWithKeyComparator(skiplist.BytesComparator{}))
     if err != nil { log.Fatalf("error: %v", err) }
     defer reader.Close()
     
@@ -121,10 +121,10 @@ for i := 0; i < numFiles; i++ {
 
 writer, err := sstables.NewSSTableSimpleWriter(
     sstables.WriteBasePath(path),
-    sstables.WithKeyComparator(skiplist.BytesComparator))
+    sstables.WithKeyComparator(skiplist.BytesComparator{}))
 if err != nil { log.Fatalf("error: %v", err) }
 
-merger := NewSSTableMerger(skiplist.BytesComparator)
+merger := NewSSTableMerger(skiplist.BytesComparator{})
 // merge takes care of opening/closing itself
 err = merger.Merge(MergeContext{
     iterators:       iterators,
@@ -146,7 +146,7 @@ reduceFunc := func(key []byte, values [][]byte, context []interface{}) ([]byte, 
     return key, values[0]
 }
 
-merger := NewSSTableMerger(skiplist.BytesComparator)
+merger := NewSSTableMerger(skiplist.BytesComparator{})
 err = merger.MergeCompact(MergeContext{
     iterators:       iterators,
     iteratorContext: iteratorContext,

--- a/sstables/priority_queue.go
+++ b/sstables/priority_queue.go
@@ -21,15 +21,15 @@ type Element struct {
 type PriorityQueue struct {
 	size int
 	heap []*Element
-	comp skiplist.KeyComparator
+	comp skiplist.Comparator[[]byte]
 }
 
-func NewPriorityQueue(comp skiplist.KeyComparator) PriorityQueue {
+func NewPriorityQueue(comp skiplist.Comparator[[]byte]) PriorityQueue {
 	return PriorityQueue{comp: comp}
 }
 
 func (pq PriorityQueue) lessThan(i, j *Element) bool {
-	return pq.comp(i.key, j.key) < 0
+	return pq.comp.Compare(i.key, j.key) < 0
 }
 
 func (pq PriorityQueue) swap(i, j int) {

--- a/sstables/priority_queue_test.go
+++ b/sstables/priority_queue_test.go
@@ -79,7 +79,7 @@ func TestMultiListAllEmpty(t *testing.T) {
 }
 
 func TestInitContextFail(t *testing.T) {
-	pq := NewPriorityQueue(skiplist.BytesComparator)
+	pq := NewPriorityQueue(skiplist.BytesComparator{})
 	err := pq.Init(MergeContext{
 		Iterators:       []SSTableIteratorI{},
 		IteratorContext: []interface{}{"a", "b"},
@@ -102,7 +102,7 @@ func assertMergeAndListMatches(t *testing.T, lists ...[]int) {
 		}
 	}
 
-	pq := NewPriorityQueue(skiplist.BytesComparator)
+	pq := NewPriorityQueue(skiplist.BytesComparator{})
 	err := pq.Init(MergeContext{
 		Iterators:       input,
 		IteratorContext: context,

--- a/sstables/sstable.go
+++ b/sstables/sstable.go
@@ -13,51 +13,52 @@ var MetaFileName = "meta.pb.bin"
 
 var Version = uint32(1)
 
-// iterator pattern as described in https://github.com/GoogleCloudPlatform/google-cloud-go/wiki/Iterator-Guidelines
+// Done indicates an iterator has returned all items.
+// https://github.com/GoogleCloudPlatform/google-cloud-go/wiki/Iterator-Guidelines
 var Done = errors.New("no more items in iterator")
 var NotFound = errors.New("key was not found")
 
 type SSTableIteratorI interface {
-	// returns the next key, value in sequence
-	// returns Done as the error when the iterator is exhausted
+	// Next returns the next key, value in sequence.
+	// Returns Done as the error when the iterator is exhausted
 	Next() ([]byte, []byte, error)
 }
 
 type SSTableReaderI interface {
-	// returns true when the given key exists, false otherwise
+	// Contains returns true when the given key exists, false otherwise
 	Contains(key []byte) bool
-	// returns the value associated with the given key, NotFound as the error otherwise
+	// Get returns the value associated with the given key, NotFound as the error otherwise
 	Get(key []byte) ([]byte, error)
-	// Returns an iterator over the whole sorted sequence. Scan uses a more optimized version that iterates the
+	// Scan returns an iterator over the whole sorted sequence. Scan uses a more optimized version that iterates the
 	// data file sequentially, whereas the other Scan* functions use the index and random access using mmap.
 	Scan() (SSTableIteratorI, error)
-	// Returns an iterator over the sorted sequence starting at the given key (inclusive if key is in the list).
+	// ScanStartingAt returns an iterator over the sorted sequence starting at the given key (inclusive if key is in the list).
 	// Using a key that is out of the sequence range will result in either an empty iterator or the full sequence.
 	ScanStartingAt(key []byte) (SSTableIteratorI, error)
-	// Returns an iterator over the sorted sequence starting at the given keyLower (inclusive if key is in the list)
+	// ScanRange returns an iterator over the sorted sequence starting at the given keyLower (inclusive if key is in the list)
 	// and until the given keyHigher was reached (inclusive if key is in the list).
 	// Using keys that are out of the sequence range will result in either an empty iterator or the full sequence.
 	// If keyHigher is lower than keyLower an error will be returned.
 	ScanRange(keyLower []byte, keyHigher []byte) (SSTableIteratorI, error)
-	// closes this sstable reader
+	// Close closes this sstable reader
 	Close() error
-	// Returns the metadata of this sstable
+	// MetaData returns the metadata of this sstable
 	MetaData() *proto.MetaData
-	// Returns the base path / root path of this sstable that contains all the files.
+	// BasePath returns the base path / root path of this sstable that contains all the files.
 	BasePath() string
 }
 
 type SSTableSimpleWriterI interface {
-	// writes all records of that SkipList to an sstable disk structure, expects []byte as key and value
-	WriteSkipList(skipListMap *skiplist.SkipListMap) error
+	// WriteSkipList writes all records of that SkipList to a sstable disk structure, expects []byte as key and value
+	WriteSkipList(skipListMap *skiplist.MapI[[]byte, []byte]) error
 }
 
 type SSTableStreamWriterI interface {
-	// opens the sstable files.
+	// Open opens the sstable files.
 	Open() error
-	// writes the next record to an sstable disk structure, expects keys to be ordered.
+	// WriteNext writes the next record to a sstable disk structure, expects keys to be ordered.
 	WriteNext(key []byte, value []byte) error
-	// closes the sstable files.
+	// Close closes the sstable files.
 	Close() error
 }
 

--- a/sstables/sstable_merger_test.go
+++ b/sstables/sstable_merger_test.go
@@ -51,7 +51,7 @@ func writeFilesMergeAndCheck(t *testing.T, numFiles int, numElementsPerFile int)
 	require.Nil(t, err)
 	defer cleanWriterDir(t, outWriter)
 
-	merger := NewSSTableMerger(skiplist.BytesComparator)
+	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.Merge(MergeContext{
 		Iterators:       iterators,
 		IteratorContext: iteratorContext,
@@ -105,7 +105,7 @@ func writeMergeCompactAndCheck(t *testing.T, numFiles int, numElementsPerFile in
 	require.Nil(t, err)
 	writersToClean = append(writersToClean, outWriter)
 
-	merger := NewSSTableMerger(skiplist.BytesComparator)
+	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.MergeCompact(MergeContext{
 		Iterators:       iterators,
 		IteratorContext: iteratorContext,
@@ -159,7 +159,7 @@ func TestOverlappingMergeAndCompact(t *testing.T) {
 		return key, values[0]
 	}
 
-	merger := NewSSTableMerger(skiplist.BytesComparator)
+	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.MergeCompact(MergeContext{
 		Iterators:       iterators,
 		IteratorContext: iteratorContext,
@@ -196,7 +196,7 @@ func TestMergeAndCompactEmptyResult(t *testing.T) {
 		return nil, nil
 	}
 
-	merger := NewSSTableMerger(skiplist.BytesComparator)
+	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.MergeCompact(MergeContext{
 		Iterators:       iterators,
 		IteratorContext: iteratorContext,

--- a/sstables/sstable_reader_generator_test.go
+++ b/sstables/sstable_reader_generator_test.go
@@ -31,7 +31,7 @@ func writeHappyPathSSTable(t *testing.T, path string) {
 func newSimpleBytesWriterAt(t *testing.T, path string) *SSTableSimpleWriter {
 	_ = os.RemoveAll(path)
 	_ = os.MkdirAll(path, 0666)
-	writer, e := NewSSTableSimpleWriter(WriteBasePath(path), WithKeyComparator(skiplist.BytesComparator))
+	writer, e := NewSSTableSimpleWriter(WriteBasePath(path), WithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, e)
 	return writer
 }

--- a/sstables/sstable_reader_test.go
+++ b/sstables/sstable_reader_test.go
@@ -11,7 +11,7 @@ import (
 func TestSimpleHappyPathReadReadRecordIOV1(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -27,7 +27,7 @@ func TestSimpleHappyPathReadReadRecordIOV1(t *testing.T) {
 func TestSimpleHappyPathReadRecordIOV2(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -41,7 +41,7 @@ func TestSimpleHappyPathReadRecordIOV2(t *testing.T) {
 func TestSimpleHappyPathBloomRead(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -56,7 +56,7 @@ func TestSimpleHappyPathBloomRead(t *testing.T) {
 func TestSimpleHappyPathWithMetaData(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -70,7 +70,7 @@ func TestSimpleHappyPathWithMetaData(t *testing.T) {
 func TestNegativeContainsHappyPath(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -80,7 +80,7 @@ func TestNegativeContainsHappyPath(t *testing.T) {
 func TestNegativeContainsHappyPathBloom(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -90,7 +90,7 @@ func TestNegativeContainsHappyPathBloom(t *testing.T) {
 func TestFullScan(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -103,7 +103,7 @@ func TestFullScan(t *testing.T) {
 func TestScanStartingAt(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -133,7 +133,7 @@ func TestScanStartingAt(t *testing.T) {
 func TestScanRange(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 

--- a/sstables/sstable_reader_v0compat_test.go
+++ b/sstables/sstable_reader_v0compat_test.go
@@ -9,7 +9,7 @@ import (
 func TestSimpleHappyPathReadReadRecordIOV1V0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -24,7 +24,7 @@ func TestSimpleHappyPathReadReadRecordIOV1V0Compat(t *testing.T) {
 func TestSimpleHappyPathReadRecordIOV2V0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -38,7 +38,7 @@ func TestSimpleHappyPathReadRecordIOV2V0Compat(t *testing.T) {
 func TestSimpleHappyPathBloomReadV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -53,7 +53,7 @@ func TestSimpleHappyPathBloomReadV0Compat(t *testing.T) {
 func TestSimpleHappyPathWithMetaDataV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -68,7 +68,7 @@ func TestSimpleHappyPathWithMetaDataV0Compat(t *testing.T) {
 func TestNegativeContainsHappyPathV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -78,7 +78,7 @@ func TestNegativeContainsHappyPathV0Compat(t *testing.T) {
 func TestNegativeContainsHappyPathBloomV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -88,7 +88,7 @@ func TestNegativeContainsHappyPathBloomV0Compat(t *testing.T) {
 func TestFullScanV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -101,7 +101,7 @@ func TestFullScanV0Compat(t *testing.T) {
 func TestScanStartingAtV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -131,7 +131,7 @@ func TestScanStartingAtV0Compat(t *testing.T) {
 func TestScanRangeV0Compat(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/v0_compat/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	assert.Nil(t, err)
 	defer closeReader(t, reader)
 

--- a/sstables/sstable_test.go
+++ b/sstables/sstable_test.go
@@ -42,7 +42,7 @@ func TestReadStreamedWriteEndToEndCheckMetadata(t *testing.T) {
 	expectedNumbers := streamedWrite1kElements(t, writer)
 	reader, err := NewSSTableReader(
 		ReadBasePath(writer.opts.basePath),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -155,7 +155,7 @@ func newTestSSTableSimpleWriter() (*SSTableSimpleWriter, error) {
 		return nil, err
 	}
 
-	return NewSSTableSimpleWriter(WriteBasePath(tmpDir), WithKeyComparator(skiplist.BytesComparator))
+	return NewSSTableSimpleWriter(WriteBasePath(tmpDir), WithKeyComparator(skiplist.BytesComparator{}))
 }
 
 func newTestSSTableStreamWriter() (*SSTableStreamWriter, error) {
@@ -164,7 +164,7 @@ func newTestSSTableStreamWriter() (*SSTableStreamWriter, error) {
 		return nil, err
 	}
 
-	return NewSSTableStreamWriter(WriteBasePath(tmpDir), WithKeyComparator(skiplist.BytesComparator))
+	return NewSSTableStreamWriter(WriteBasePath(tmpDir), WithKeyComparator(skiplist.BytesComparator{}))
 }
 
 func newTestSSTableStreamWriterWithDataCompression(compressionType int) (*SSTableStreamWriter, error) {
@@ -175,7 +175,7 @@ func newTestSSTableStreamWriterWithDataCompression(compressionType int) (*SSTabl
 
 	return NewSSTableStreamWriter(
 		WriteBasePath(tmpDir),
-		WithKeyComparator(skiplist.BytesComparator),
+		WithKeyComparator(skiplist.BytesComparator{}),
 		DataCompressionType(compressionType))
 }
 
@@ -187,7 +187,7 @@ func newTestSSTableStreamWriterWithIndexCompression(compressionType int) (*SSTab
 
 	return NewSSTableStreamWriter(
 		WriteBasePath(tmpDir),
-		WithKeyComparator(skiplist.BytesComparator),
+		WithKeyComparator(skiplist.BytesComparator{}),
 		IndexCompressionType(compressionType))
 }
 
@@ -209,8 +209,8 @@ func randomIntegerSlice(len int) []int {
 }
 
 //noinspection GoSnakeCaseUsage
-func TEST_ONLY_NewSkipListMapWithElements(toInsert []int) skiplist.SkipListMapI {
-	list := skiplist.NewSkipListMap(skiplist.BytesComparator)
+func TEST_ONLY_NewSkipListMapWithElements(toInsert []int) skiplist.MapI[[]byte, []byte] {
+	list := skiplist.NewSkipListMap[[]byte, []byte](skiplist.BytesComparator{})
 	for _, e := range toInsert {
 		key, value := getKeyValueAsBytes(e)
 		list.Insert(key, value)
@@ -257,7 +257,7 @@ func assertIteratorMatchesSlice(t *testing.T, it SSTableIteratorI, expectedSlice
 	require.Nil(t, v)
 }
 
-func assertContentMatchesSkipList(t *testing.T, reader SSTableReaderI, expectedSkipListMap skiplist.SkipListMapI) {
+func assertContentMatchesSkipList(t *testing.T, reader SSTableReaderI, expectedSkipListMap skiplist.MapI[[]byte, []byte]) {
 	it, _ := expectedSkipListMap.Iterator()
 	numRead := 0
 	for {
@@ -267,8 +267,8 @@ func assertContentMatchesSkipList(t *testing.T, reader SSTableReaderI, expectedS
 		}
 		require.Nil(t, err)
 
-		assert.True(t, reader.Contains(expectedKey.([]byte)))
-		actualValue, err := reader.Get(expectedKey.([]byte))
+		assert.True(t, reader.Contains(expectedKey))
+		actualValue, err := reader.Get(expectedKey)
 		require.Nil(t, err)
 		assert.Equal(t, expectedValue, actualValue)
 		numRead++
@@ -280,7 +280,7 @@ func assertContentMatchesSkipList(t *testing.T, reader SSTableReaderI, expectedS
 func getFullScanIterator(t *testing.T, sstablePath string) (SSTableReaderI, SSTableIteratorI) {
 	reader, err := NewSSTableReader(
 		ReadBasePath(sstablePath),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 
 	it, err := reader.Scan()
@@ -291,7 +291,7 @@ func getFullScanIterator(t *testing.T, sstablePath string) (SSTableReaderI, SSTa
 func assertRandomAndSequentialRead(t *testing.T, sstablePath string, expectedNumbers []int) {
 	reader, err := NewSSTableReader(
 		ReadBasePath(sstablePath),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
@@ -312,7 +312,7 @@ func assertRandomAndSequentialRead(t *testing.T, sstablePath string, expectedNum
 func assertExhaustiveRangeReads(t *testing.T, sstablePath string, expectedNumbers []int) {
 	reader, err := NewSSTableReader(
 		ReadBasePath(sstablePath),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 

--- a/sstables/sstable_writer_test.go
+++ b/sstables/sstable_writer_test.go
@@ -83,12 +83,12 @@ func TestComparatorNotSupplied(t *testing.T) {
 }
 
 func TestDirectoryDoesNotExist(t *testing.T) {
-	_, err := NewSSTableSimpleWriter(WithKeyComparator(skiplist.BytesComparator))
+	_, err := NewSSTableSimpleWriter(WithKeyComparator(skiplist.BytesComparator{}))
 	assert.Equal(t, errors.New("basePath was not supplied"), err)
 }
 
 func TestUnopenedWrites(t *testing.T) {
-	w, err := NewSSTableSimpleWriter(WriteBasePath("abc"), WithKeyComparator(skiplist.BytesComparator))
+	w, err := NewSSTableSimpleWriter(WriteBasePath("abc"), WithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	err = w.streamWriter.WriteNext([]byte{1}, []byte{1})
 	assert.Contains(t, err.Error(), "no metadata available to write into, table might not be opened yet")
@@ -98,7 +98,7 @@ func TestCompressionTypeDoesNotExist(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "sstables_Writer")
 	defer func() { require.Nil(t, os.RemoveAll(tmpDir)) }()
 	require.Nil(t, err)
-	writer, err := NewSSTableSimpleWriter(WriteBasePath(tmpDir), DataCompressionType(25), WithKeyComparator(skiplist.BytesComparator))
+	writer, err := NewSSTableSimpleWriter(WriteBasePath(tmpDir), DataCompressionType(25), WithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	err = writer.WriteSkipListMap(TEST_ONLY_NewSkipListMapWithElements([]int{}))
 	assert.Equal(t, errors.New("unsupported compression type 25"), errors.Unwrap(errors.Unwrap(err)))
@@ -108,7 +108,7 @@ func TestCompressionTypeDoesNotExist(t *testing.T) {
 func TestEmptyBloomFilter(t *testing.T) {
 	_, err := NewSSTableSimpleWriter(
 		WriteBasePath("abc"),
-		WithKeyComparator(skiplist.BytesComparator),
+		WithKeyComparator(skiplist.BytesComparator{}),
 		BloomExpectedNumberOfElements(0))
 	assert.Equal(t, errors.New("unexpected number of bloom filter elements, was: 0"), err)
 }

--- a/sstables/super_sstable_reader.go
+++ b/sstables/super_sstable_reader.go
@@ -10,7 +10,7 @@ import (
 // The ordering of the readers matters, it is assumed the older reader comes before the newer (ascending order).
 type SuperSSTableReader struct {
 	readers []SSTableReaderI
-	comp    skiplist.KeyComparator
+	comp    skiplist.Comparator[[]byte]
 }
 
 func (s SuperSSTableReader) Contains(key []byte) bool {
@@ -164,11 +164,11 @@ func (s SuperSSTableReader) MetaData() *proto.MetaData {
 		sum.IndexBytes += m.IndexBytes
 		sum.TotalBytes += m.TotalBytes
 		sum.Version = m.Version // assuming all have the same version anyway
-		if s.comp(sum.MinKey, m.MinKey) < 0 {
+		if s.comp.Compare(sum.MinKey, m.MinKey) < 0 {
 			sum.MinKey = m.MinKey
 		}
 
-		if s.comp(sum.MaxKey, m.MaxKey) < 0 {
+		if s.comp.Compare(sum.MaxKey, m.MaxKey) < 0 {
 			sum.MaxKey = m.MaxKey
 		}
 	}
@@ -184,6 +184,6 @@ func (s SuperSSTableReader) BasePath() string {
 	return strings.Join(paths, ",")
 }
 
-func NewSuperSSTableReader(readers []SSTableReaderI, comp skiplist.KeyComparator) *SuperSSTableReader {
+func NewSuperSSTableReader(readers []SSTableReaderI, comp skiplist.Comparator[[]byte]) *SuperSSTableReader {
 	return &SuperSSTableReader{readers: readers, comp: comp}
 }

--- a/sstables/super_sstable_reader_test.go
+++ b/sstables/super_sstable_reader_test.go
@@ -10,13 +10,13 @@ import (
 func TestSuperSimpleHappyPathReadReadRecordIOV1(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	// 0 because there was no metadata file
@@ -31,13 +31,13 @@ func TestSuperSimpleHappyPathReadReadRecordIOV1(t *testing.T) {
 func TestSuperSimpleHappyPathReadRecordIOV2(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assert.Equal(t, 7, int(reader.MetaData().NumRecords))
@@ -50,19 +50,19 @@ func TestSuperSimpleHappyPathReadRecordIOV2(t *testing.T) {
 func TestSuperSimpleHappyPathReadRecordIOV2Overlapping(t *testing.T) {
 	reader1, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader1)
 
 	reader2, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader2)
 
 	reader := SuperSSTableReader{
 		readers: []SSTableReaderI{reader1, reader2},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assert.Equal(t, 14, int(reader.MetaData().NumRecords))
@@ -75,13 +75,13 @@ func TestSuperSimpleHappyPathReadRecordIOV2Overlapping(t *testing.T) {
 func TestSuperSimpleHappyPathBloomRead(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assert.Equal(t, 1, int(reader.MetaData().Version))
@@ -95,13 +95,13 @@ func TestSuperSimpleHappyPathBloomRead(t *testing.T) {
 func TestSuperSimpleHappyPathWithMetaData(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assert.Equal(t, 7, int(reader.MetaData().NumRecords))
@@ -114,13 +114,13 @@ func TestSuperSimpleHappyPathWithMetaData(t *testing.T) {
 func TestSuperNegativeContainsHappyPath(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTable"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assertNegativeContains(t, reader)
@@ -129,13 +129,13 @@ func TestSuperNegativeContainsHappyPath(t *testing.T) {
 func TestSuperNegativeContainsHappyPathBloom(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithBloom"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	assertNegativeContains(t, reader)
@@ -144,13 +144,13 @@ func TestSuperNegativeContainsHappyPathBloom(t *testing.T) {
 func TestSuperFullScan(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
@@ -162,19 +162,19 @@ func TestSuperFullScan(t *testing.T) {
 func TestSuperFullScanOverlapping(t *testing.T) {
 	reader1, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader1)
 
 	reader2, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader2)
 
 	reader := SuperSSTableReader{
 		readers: []SSTableReaderI{reader1, reader2},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
@@ -186,13 +186,13 @@ func TestSuperFullScanOverlapping(t *testing.T) {
 func TestSuperScanStartingAt(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
@@ -221,13 +221,13 @@ func TestSuperScanStartingAt(t *testing.T) {
 func TestSuperScanRange(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithMetaData"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader)
 
 	reader = SuperSSTableReader{
 		readers: []SSTableReaderI{reader},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	expected := []int{1, 2, 3, 4, 5, 6, 7}
@@ -305,19 +305,19 @@ func TestSuperStaggeredAndOverlappingFull(t *testing.T) {
 
 	reader1, err := NewSSTableReader(
 		ReadBasePath(writer.streamWriter.opts.basePath),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader1)
 
 	reader2, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableRecordIOV2"),
-		ReadWithKeyComparator(skiplist.BytesComparator))
+		ReadWithKeyComparator(skiplist.BytesComparator{}))
 	require.Nil(t, err)
 	defer closeReader(t, reader2)
 
 	reader := SuperSSTableReader{
 		readers: []SSTableReaderI{reader1, reader2},
-		comp:    skiplist.BytesComparator,
+		comp:    skiplist.BytesComparator{},
 	}
 
 	expected := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}


### PR DESCRIPTION
This moves the whole project to 1.18, skiplist will stay maintain a non-generic version for backward compatibility on that package only.

