### PR TITLE
using errors.is

### DIFF
--- a/_examples/simpledb.go
+++ b/_examples/simpledb.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -35,7 +36,7 @@ func main() {
 	log.Printf("get 'hello' = %s", get)
 
 	_, err = db.Get("not found")
-	if err == simpledb.ErrNotFound {
+	if errors.Is(err, simpledb.ErrNotFound) {
 		log.Printf("not found!")
 	}
 

--- a/_examples/skiplist.go
+++ b/_examples/skiplist.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"log"
 )
@@ -16,7 +17,7 @@ func main() {
 	it, _ := skipListMap.Iterator()
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)
@@ -26,7 +27,7 @@ func main() {
 	it, _ = skipListMap.IteratorStartingAt(5)
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)
@@ -36,7 +37,7 @@ func main() {
 	it, _ = skipListMap.IteratorBetween(8, 50)
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)

--- a/_examples/sstables.go
+++ b/_examples/sstables.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
 	"log"
@@ -40,7 +41,7 @@ func mainSimpleRead(path string) {
 	for {
 		k, v, err := it.Next()
 		// io.EOF signals that no records are left to be read
-		if err == sstables.Done {
+		if errors.Is(err, sstables.Done) {
 			break
 		}
 

--- a/benchmark/sstable_read_test.go
+++ b/benchmark/sstable_read_test.go
@@ -2,6 +2,7 @@ package benchmark
 
 import (
 	"encoding/binary"
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
@@ -40,7 +41,7 @@ func fullScanTable(b *testing.B, tmpDir string, cmp skiplist.Comparator[[]byte])
 		assert.Nil(b, err)
 		for {
 			_, _, err := scanner.Next()
-			if err == sstables.Done {
+			if errors.Is(err, sstables.Done) {
 				break
 			}
 		}

--- a/memstore/memstore_sstable_iterator.go
+++ b/memstore/memstore_sstable_iterator.go
@@ -1,6 +1,7 @@
 package memstore
 
 import (
+	"errors"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
 )
@@ -12,7 +13,7 @@ type SkipListSStableIterator struct {
 func (s SkipListSStableIterator) Next() ([]byte, []byte, error) {
 	key, val, err := s.iterator.Next()
 	if err != nil {
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			return nil, nil, sstables.Done
 		} else {
 			return nil, nil, err

--- a/pq/priority_queue.go
+++ b/pq/priority_queue.go
@@ -57,7 +57,7 @@ func (pq *PriorityQueue[K, V, CTX]) init(iterators []IteratorWithContext[K, V, C
 			pq.heap = append(pq.heap, e)
 			pq.size++
 			pq.upHeap(pq.size)
-		} else if err != Done {
+		} else if !errors.Is(err, Done) {
 			return fmt.Errorf("INIT couldn't fill next heap entry: %w", err)
 		}
 	}
@@ -78,13 +78,13 @@ func (pq *PriorityQueue[K, V, CTX]) Next() (_ K, _ V, _ CTX, err error) {
 	c := top.iterator.Context()
 	err = pq.fillNext(top)
 	// if we encounter a real error, we're returning immediately
-	if err != nil && err != Done {
+	if err != nil && !errors.Is(err, Done) {
 		err = fmt.Errorf("NEXT couldn't fill next heap entry: %w", err)
 		return
 	}
 
 	// remove the element from the heap completely if its iterator is exhausted
-	if err == Done {
+	if errors.Is(err, Done) {
 		// move the root away to the bottom leaf
 		pq.swap(1, pq.size)
 		// and chop it off the slice

--- a/pq/priority_queue_test.go
+++ b/pq/priority_queue_test.go
@@ -1,6 +1,7 @@
 package pq
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomasjungblut/go-sstables/skiplist"
@@ -96,7 +97,7 @@ func assertMergeAndListMatches(t *testing.T, lists ...[]int) {
 	var actualKeys []int
 	for {
 		k, v, _, err := pq.Next()
-		if err == Done {
+		if errors.Is(err, Done) {
 			break
 		}
 

--- a/simpledb/README.md
+++ b/simpledb/README.md
@@ -53,7 +53,7 @@ if err != nil { log.Fatalf("error: %v", err) }
 ```go
 value, err = db.Get("hello")
 if err != nil {
-    if err == simpledb.ErrNotFound {
+    if errors.is(err, simpledb.ErrNotFound) {
         log.Printf("no value found!")
     } else {
         log.Fatalf("error: %v", err)

--- a/simpledb/_crash_tests/crash_test.go
+++ b/simpledb/_crash_tests/crash_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -234,7 +235,7 @@ func spawnNewDatabaseServer(t *testing.T, path string) *exec.Cmd {
 	// wait until the DB is up
 	for {
 		_, err := newRequestClient(0).Get("SOME_KEY")
-		if err != nil && err == simpledb.ErrNotFound {
+		if err != nil && errors.Is(err, simpledb.ErrNotFound) {
 			break
 		}
 

--- a/simpledb/_crash_tests/simpledb_web_server.go
+++ b/simpledb/_crash_tests/simpledb_web_server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -21,7 +22,7 @@ type Server struct {
 func (s *Server) handleGet(w http.ResponseWriter, key string) {
 	get, err := s.db.Get(key)
 	if err != nil {
-		if err == simpledb.ErrNotFound {
+		if errors.Is(err, simpledb.ErrNotFound) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		} else {

--- a/simpledb/db.go
+++ b/simpledb/db.go
@@ -193,7 +193,7 @@ func (db *DB) Get(key string) (string, error) {
 	var sstableNotFound bool
 	ssTableVal, err := db.sstableManager.currentSSTable().Get(keyBytes)
 	if err != nil {
-		if err == sstables.NotFound {
+		if errors.Is(err, sstables.NotFound) {
 			sstableNotFound = true
 		} else {
 			return "", err
@@ -204,13 +204,13 @@ func (db *DB) Get(key string) (string, error) {
 
 	memStoreVal, err := db.memStore.Get(keyBytes)
 	if err != nil {
-		if err == memstore.KeyNotFound {
+		if errors.Is(err, memstore.KeyNotFound) {
 			if sstableNotFound {
 				return "", ErrNotFound
 			} else {
 				return string(ssTableVal), nil
 			}
-		} else if err == memstore.KeyTombstoned {
+		} else if errors.Is(err, memstore.KeyTombstoned) {
 			// regardless of what we found on the sstable:
 			// if the memstore says it's tombstoned it's considered deleted
 			return "", ErrNotFound

--- a/simpledb/porcupine/model.go
+++ b/simpledb/porcupine/model.go
@@ -1,6 +1,7 @@
 package porcupine
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -87,7 +88,7 @@ var Model = pp.Model[MapState, Input, Output]{
 
 		switch i.Operation {
 		case GetOp:
-			if o.Err == simpledb.ErrNotFound {
+			if errors.Is(o.Err, simpledb.ErrNotFound) {
 				return !found, s
 			} else if stateVal == o.Val {
 				return true, s

--- a/simpledb/rw_memstore.go
+++ b/simpledb/rw_memstore.go
@@ -1,6 +1,7 @@
 package simpledb
 
 import (
+	"errors"
 	"github.com/thomasjungblut/go-sstables/memstore"
 	"github.com/thomasjungblut/go-sstables/sstables"
 )
@@ -23,7 +24,7 @@ func (c *RWMemstore) Get(key []byte) ([]byte, error) {
 	// in the writeStore the readStore is the source of truth
 	writeVal, writeErr := c.writeStore.Get(key)
 	if writeErr != nil {
-		if writeErr == memstore.KeyNotFound {
+		if errors.Is(writeErr, memstore.KeyNotFound) {
 			return c.readStore.Get(key)
 		}
 
@@ -46,7 +47,7 @@ func (c *RWMemstore) Upsert(key []byte, value []byte) error {
 
 func (c *RWMemstore) Delete(key []byte) error {
 	err := c.writeStore.Delete(key)
-	if err == memstore.KeyNotFound {
+	if errors.Is(err, memstore.KeyNotFound) {
 		return c.Tombstone(key)
 	}
 

--- a/skiplist/README.md
+++ b/skiplist/README.md
@@ -25,7 +25,7 @@ func main() {
 	it, _ := skipListMap.Iterator()
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)
@@ -35,7 +35,7 @@ func main() {
 	it, _ = skipListMap.IteratorStartingAt(5)
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)
@@ -45,7 +45,7 @@ func main() {
 	it, _ = skipListMap.IteratorBetween(8, 50)
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.is(err, skiplist.Done) {
 			break
 		}
 		log.Printf("key: %d, value: %d", k, v)

--- a/skiplist/map_generic_test.go
+++ b/skiplist/map_generic_test.go
@@ -1,6 +1,7 @@
 package skiplist
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"reflect"
@@ -182,7 +183,7 @@ func TestSkipListBetweenIteratorScanOverHoles(t *testing.T) {
 	currentIndex := 0
 	for {
 		k, v, err := it.Next()
-		if err == Done {
+		if errors.Is(err, Done) {
 			break
 		}
 
@@ -216,7 +217,7 @@ func TestSkipListSortedQuick(t *testing.T) {
 		result := []int{}
 		for {
 			k, _, err := iterator.Next()
-			if err == Done {
+			if errors.Is(err, Done) {
 				break
 			}
 			if err != nil {
@@ -257,7 +258,7 @@ func TestSkipListRangeScanQuick(t *testing.T) {
 		result := []int{}
 		for {
 			k, _, err := iterator.Next()
-			if err == Done {
+			if errors.Is(err, Done) {
 				break
 			}
 			if err != nil {
@@ -294,7 +295,7 @@ func assertIteratorOutputs(t *testing.T, expectedSeq []int, it IteratorI[int, in
 	currentIndex := 0
 	for {
 		k, v, err := it.Next()
-		if err == Done {
+		if errors.Is(err, Done) {
 			break
 		}
 

--- a/sstables/README.md
+++ b/sstables/README.md
@@ -84,7 +84,7 @@ it, err := reader.ScanRange([]byte{1}, []byte{2})
 for {
     k, v, err := it.Next()
     // io.EOF signals that no records are left to be read
-    if err == sstables.Done {
+    if errors.is(err, sstables.Done) {
         break
     }
     if err != nil { log.Fatalf("error: %v", err) }

--- a/sstables/sstable_iterator.go
+++ b/sstables/sstable_iterator.go
@@ -16,7 +16,7 @@ type SSTableIterator struct {
 func (it *SSTableIterator) Next() ([]byte, []byte, error) {
 	key, valueOffset, err := it.keyIterator.Next()
 	if err != nil {
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			return nil, nil, Done
 		} else {
 			return nil, nil, err
@@ -75,7 +75,7 @@ type SSTableFullScanIterator struct {
 func (it *SSTableFullScanIterator) Next() ([]byte, []byte, error) {
 	key, _, err := it.keyIterator.Next()
 	if err != nil {
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			return nil, nil, Done
 		} else {
 			return nil, nil, err

--- a/sstables/sstable_merger.go
+++ b/sstables/sstable_merger.go
@@ -1,6 +1,7 @@
 package sstables
 
 import (
+	"errors"
 	"fmt"
 	"github.com/thomasjungblut/go-sstables/pq"
 	"github.com/thomasjungblut/go-sstables/skiplist"
@@ -13,7 +14,7 @@ type SSTableMergeIteratorContext struct {
 
 func (s SSTableMergeIteratorContext) Next() ([]byte, []byte, error) {
 	k, v, err := s.iterator.Next()
-	if err == Done {
+	if errors.Is(err, Done) {
 		return nil, nil, pq.Done
 	}
 	return k, v, nil
@@ -52,7 +53,7 @@ func (m SSTableMerger) Merge(iterators []SSTableMergeIteratorContext, writer SST
 	for {
 		k, v, _, err := pqq.Next()
 		if err != nil {
-			if err == pq.Done {
+			if errors.Is(err, pq.Done) {
 				break
 			} else {
 				return fmt.Errorf("merge error during heap next: %w", err)
@@ -86,7 +87,7 @@ func (m *MergeCompactionIterator) Next() ([]byte, []byte, error) {
 	for {
 		k, v, c, err := m.pq.Next()
 		if err != nil {
-			if err == pq.Done {
+			if errors.Is(err, pq.Done) {
 				if len(m.valBuf) > 0 {
 					kReduced, vReduced := m.reduce(m.prevKey, m.valBuf, m.ctxBuf)
 					if kReduced != nil && vReduced != nil {
@@ -164,7 +165,7 @@ func (m SSTableMerger) MergeCompact(iterators []SSTableMergeIteratorContext, wri
 	for {
 		k, v, err := iterator.Next()
 		if err != nil {
-			if err == Done {
+			if errors.Is(err, Done) {
 				break
 			} else {
 				return fmt.Errorf("merge compact error while iterating: %w", err)

--- a/sstables/sstable_reader.go
+++ b/sstables/sstable_reader.go
@@ -42,7 +42,7 @@ func (reader *SSTableReader) Contains(key []byte) bool {
 
 func (reader *SSTableReader) Get(key []byte) ([]byte, error) {
 	valOffset, err := reader.index.Get(key)
-	if err == skiplist.NotFound {
+	if errors.Is(err, skiplist.NotFound) {
 		return nil, NotFound
 	}
 

--- a/sstables/sstable_test.go
+++ b/sstables/sstable_test.go
@@ -2,6 +2,7 @@ package sstables
 
 import (
 	"encoding/binary"
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomasjungblut/go-sstables/recordio"
@@ -261,7 +262,7 @@ func assertContentMatchesSkipList(t *testing.T, reader SSTableReaderI, expectedS
 	numRead := 0
 	for {
 		expectedKey, expectedValue, err := it.Next()
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			break
 		}
 		require.Nil(t, err)

--- a/sstables/sstable_writer.go
+++ b/sstables/sstable_writer.go
@@ -184,7 +184,7 @@ func (writer *SSTableSimpleWriter) WriteSkipListMap(skipListMap skiplist.MapI[[]
 	it, _ := skipListMap.Iterator()
 	for {
 		k, v, err := it.Next()
-		if err == skiplist.Done {
+		if errors.Is(err, skiplist.Done) {
 			break
 		}
 		if err != nil {

--- a/sstables/super_sstable_reader.go
+++ b/sstables/super_sstable_reader.go
@@ -1,6 +1,7 @@
 package sstables
 
 import (
+	"errors"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables/proto"
 	"strings"
@@ -16,7 +17,7 @@ type SuperSSTableReader struct {
 func (s SuperSSTableReader) Contains(key []byte) bool {
 	// this can't be implemented using contains because NotFound is the same as false, thus we have to go via Get
 	_, err := s.Get(key)
-	if err != nil && err == NotFound {
+	if err != nil && errors.Is(err, NotFound) {
 		return false
 	}
 	return true
@@ -27,7 +28,7 @@ func (s SuperSSTableReader) Get(key []byte) ([]byte, error) {
 	for i := len(s.readers) - 1; i >= 0; i-- {
 		res, err := s.readers[i].Get(key)
 		if err != nil {
-			if err == NotFound {
+			if errors.Is(err, NotFound) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
when I started the project errors.Is didn't exist yet, this PR cleans it up to make use of it instead of equality comparison.