### PR TITLE
ensure close is called

### DIFF
--- a/simpledb/db.go
+++ b/simpledb/db.go
@@ -161,17 +161,7 @@ func (db *DB) Close() error {
 		<-db.doneCompactionChannel
 	}
 
-	err = db.wal.Close()
-	if err != nil {
-		return err
-	}
-
-	err = db.sstableManager.currentSSTable().Close()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return errors.Join(db.wal.Close(), db.sstableManager.currentSSTable().Close())
 }
 
 func (db *DB) Get(key string) (string, error) {

--- a/simpledb/sstable_manager.go
+++ b/simpledb/sstable_manager.go
@@ -5,6 +5,7 @@ import (
 	"github.com/thomasjungblut/go-sstables/simpledb/proto"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
+	"golang.org/x/exp/slices"
 	"os"
 	"path/filepath"
 	"sort"
@@ -150,10 +151,7 @@ func removeReaderAt(slice []sstables.SSTableReaderI, i int) []sstables.SSTableRe
 }
 
 func indexOfReader(slice []sstables.SSTableReaderI, p string) int {
-	for i := 0; i < len(slice); i++ {
-		if filepath.Base(slice[i].BasePath()) == p {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(slice, func(i sstables.SSTableReaderI) bool {
+		return filepath.Base(i.BasePath()) == p
+	})
 }

--- a/sstables/sstable_merger_test.go
+++ b/sstables/sstable_merger_test.go
@@ -45,11 +45,14 @@ func writeFilesMergeAndCheck(t *testing.T, numFiles int, numElementsPerFile int)
 
 	outWriter, err := newTestSSTableStreamWriter()
 	require.Nil(t, err)
+
+	require.NoError(t, outWriter.Open())
 	defer cleanWriterDir(t, outWriter)
 
 	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.Merge(iterators, outWriter)
 	require.Nil(t, err)
+	require.NoError(t, outWriter.Close())
 	sort.Ints(expectedNumbers)
 	assertRandomAndSequentialRead(t, outWriter.opts.basePath, expectedNumbers)
 }
@@ -94,6 +97,8 @@ func writeMergeCompactAndCheck(t *testing.T, numFiles int, numElementsPerFile in
 
 	outWriter, err := newTestSSTableStreamWriter()
 	require.Nil(t, err)
+
+	require.NoError(t, outWriter.Open())
 	writersToClean = append(writersToClean, outWriter)
 
 	merger := NewSSTableMerger(skiplist.BytesComparator{})
@@ -106,6 +111,7 @@ func writeMergeCompactAndCheck(t *testing.T, numFiles int, numElementsPerFile in
 			return key, values[0]
 		})
 	require.Nil(t, err)
+	require.Nil(t, outWriter.Close())
 	sort.Ints(expectedNumbers)
 	assertRandomAndSequentialRead(t, outWriter.opts.basePath, expectedNumbers)
 }
@@ -138,6 +144,7 @@ func TestOverlappingMergeAndCompact(t *testing.T) {
 
 	outWriter, err := newTestSSTableStreamWriter()
 	require.Nil(t, err)
+	require.NoError(t, outWriter.Open())
 	defer cleanWriterDir(t, outWriter)
 
 	reduceFunc := func(key []byte, values [][]byte, context []int) ([]byte, []byte) {
@@ -148,6 +155,7 @@ func TestOverlappingMergeAndCompact(t *testing.T) {
 	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.MergeCompact(iterators, outWriter, reduceFunc)
 	require.Nil(t, err)
+	require.Nil(t, outWriter.Close())
 	sort.Ints(expectedNumbers)
 	assertRandomAndSequentialRead(t, outWriter.opts.basePath, expectedNumbers)
 }
@@ -170,6 +178,8 @@ func TestMergeAndCompactEmptyResult(t *testing.T) {
 
 	outWriter, err := newTestSSTableStreamWriter()
 	require.Nil(t, err)
+
+	require.NoError(t, outWriter.Open())
 	defer cleanWriterDir(t, outWriter)
 
 	reduceFunc := func(key []byte, values [][]byte, context []int) ([]byte, []byte) {
@@ -180,5 +190,6 @@ func TestMergeAndCompactEmptyResult(t *testing.T) {
 	merger := NewSSTableMerger(skiplist.BytesComparator{})
 	err = merger.MergeCompact(iterators, outWriter, reduceFunc)
 	require.Nil(t, err)
+	require.Nil(t, outWriter.Close())
 	assertRandomAndSequentialRead(t, outWriter.opts.basePath, []int{})
 }

--- a/sstables/super_sstable_reader.go
+++ b/sstables/super_sstable_reader.go
@@ -112,14 +112,11 @@ func ScanReduceLatestWins(key []byte, values [][]byte, context []int) ([]byte, [
 	return key, values[maxCtxIndex]
 }
 
-func (s SuperSSTableReader) Close() error {
+func (s SuperSSTableReader) Close() (err error) {
 	for _, reader := range s.readers {
-		err := reader.Close()
-		if err != nil {
-			return err
-		}
+		err = errors.Join(err, reader.Close())
 	}
-	return nil
+	return
 }
 
 func (s SuperSSTableReader) MetaData() *proto.MetaData {

--- a/wal/replayer_test.go
+++ b/wal/replayer_test.go
@@ -45,5 +45,5 @@ func TestReplayHonorsCallbackErrors(t *testing.T) {
 	err = repl.Replay(func(record []byte) error {
 		return testErr
 	})
-	assert.Equal(t, testErr, errors.Unwrap(err))
+	assert.True(t, errors.Is(err, testErr))
 }


### PR DESCRIPTION
After reviewing the code again, I've found many instances of dangling readers and writers that were not properly closed.

This moves a good chunk of those instances to a defer/errors.join approach, that should keep the errors and still attempt to close the underlying resources.