### PR TITLE
running betteralign on the project code

### DIFF
--- a/recordio/common_reader.go
+++ b/recordio/common_reader.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Header struct {
-	compressionType int
 	compressor      compressor.CompressionI
+	compressionType int
 	fileVersion     uint32
 }
 
@@ -20,17 +20,14 @@ func readFileHeaderFromBuffer(buffer []byte) (*Header, error) {
 	if len(buffer) != FileHeaderSizeBytes {
 		return nil, fmt.Errorf("file header buffer size mismatch, expected %d but was %d", FileHeaderSizeBytes, len(buffer))
 	}
-
 	fileVersion := binary.LittleEndian.Uint32(buffer[0:4])
 	if fileVersion > CurrentVersion || fileVersion < Version1 {
 		return nil, fmt.Errorf("version mismatch, expected a value from %d to %d but was %d", Version1, CurrentVersion, fileVersion)
 	}
-
 	compressionType := binary.LittleEndian.Uint32(buffer[4:8])
 	if compressionType > CompressionTypeLzw {
 		return nil, fmt.Errorf("unknown compression type [%d]", compressionType)
 	}
-
 	header := &Header{compressionType: int(compressionType), fileVersion: fileVersion}
 	cmp, err := NewCompressorForType(header.compressionType)
 	if err != nil {
@@ -39,22 +36,18 @@ func readFileHeaderFromBuffer(buffer []byte) (*Header, error) {
 	header.compressor = cmp
 	return header, nil
 }
-
 func readRecordHeaderV1(buffer []byte) (uint64, uint64, error) {
 	if len(buffer) != RecordHeaderSizeBytes {
 		return 0, 0, fmt.Errorf("record header buffer size mismatch, expected %d but was %d", RecordHeaderSizeBytes, len(buffer))
 	}
-
 	magicNumber := binary.LittleEndian.Uint32(buffer[0:4])
 	if magicNumber != MagicNumberSeparator {
 		return 0, 0, MagicNumberMismatchErr
 	}
-
 	payloadSizeUncompressed := binary.LittleEndian.Uint64(buffer[4:12])
 	payloadSizeCompressed := binary.LittleEndian.Uint64(buffer[12:20])
 	return payloadSizeUncompressed, payloadSizeCompressed, nil
 }
-
 func readRecordHeaderV2(r io.ByteReader) (uint64, uint64, error) {
 	magicNumber, err := binary.ReadUvarint(r)
 	if err != nil {
@@ -63,34 +56,27 @@ func readRecordHeaderV2(r io.ByteReader) (uint64, uint64, error) {
 	if magicNumber != MagicNumberSeparatorLong {
 		return 0, 0, MagicNumberMismatchErr
 	}
-
 	payloadSizeUncompressed, err := binary.ReadUvarint(r)
 	if err != nil {
 		return 0, 0, err
 	}
-
 	payloadSizeCompressed, err := binary.ReadUvarint(r)
 	if err != nil {
 		return 0, 0, err
 	}
-
 	return payloadSizeUncompressed, payloadSizeCompressed, nil
 }
-
 func allocateRecordBuffer(header *Header, payloadSizeUncompressed uint64, payloadSizeCompressed uint64) (uint64, []byte) {
 	expectedBytesRead := payloadSizeUncompressed
 	if header.compressor != nil {
 		expectedBytesRead = payloadSizeCompressed
 	}
-
 	return expectedBytesRead, make([]byte, expectedBytesRead)
 }
-
 func allocateRecordBufferPooled(bufferPool *pool.BufferPool, header *Header, payloadSizeUncompressed uint64, payloadSizeCompressed uint64) (uint64, []byte) {
 	expectedBytesRead := payloadSizeUncompressed
 	if header.compressor != nil {
 		expectedBytesRead = payloadSizeCompressed
 	}
-
 	return expectedBytesRead, bufferPool.Get(int(expectedBytesRead))
 }

--- a/recordio/file_writer.go
+++ b/recordio/file_writer.go
@@ -4,11 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
-
 	pool "github.com/libp2p/go-buffer-pool"
-
 	"github.com/thomasjungblut/go-sstables/recordio/compressor"
+	"os"
 )
 
 // FileWriter defines a binary file format (little endian).
@@ -19,16 +17,15 @@ import (
 // - Compressed data payload size (encoding/binary/Uvarint), or 0 if the data is not compressed.
 // - Payload as plain bytes, possibly compressed
 type FileWriter struct {
-	open   bool
-	closed bool
-
-	file               *os.File
 	bufWriter          WriteCloserFlusher
+	compressor         compressor.CompressionI
+	file               *os.File
+	bufferPool         *pool.BufferPool
+	recordHeaderCache  []byte
 	currentOffset      uint64
 	compressionType    int
-	compressor         compressor.CompressionI
-	recordHeaderCache  []byte
-	bufferPool         *pool.BufferPool
+	open               bool
+	closed             bool
 	alignedBlockWrites bool
 }
 
@@ -38,26 +35,21 @@ func (w *FileWriter) Open() error {
 	if w.open {
 		return fmt.Errorf("file writer for '%s' is already opened", w.file.Name())
 	}
-
 	if w.closed {
 		return fmt.Errorf("file writer for '%s' is already closed", w.file.Name())
 	}
-
 	offset, err := writeFileHeader(w)
 	if err != nil {
 		return fmt.Errorf("writing header in file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	w.compressor, err = NewCompressorForType(w.compressionType)
 	if err != nil {
 		return fmt.Errorf("creating compressor with type '%d' in file at '%s' failed with %w", w.compressionType, w.file.Name(), err)
 	}
-
 	w.currentOffset = uint64(offset)
 	w.open = true
 	w.recordHeaderCache = make([]byte, RecordHeaderV2MaxSizeBytes)
 	w.bufferPool = new(pool.BufferPool)
-
 	// we flush early to get a valid file with header written, this is important in crash scenarios
 	// when directIO is enabled however, we can't write misaligned blocks - thus this is not executed
 	if !w.alignedBlockWrites {
@@ -66,19 +58,15 @@ func (w *FileWriter) Open() error {
 			return fmt.Errorf("flushing header in file at '%s' failed with %w", w.file.Name(), err)
 		}
 	}
-
 	return nil
 }
-
 func writeFileHeader(writer *FileWriter) (int, error) {
 	written, err := writer.bufWriter.Write(fileHeaderAsByteSlice(uint32(writer.compressionType)))
 	if err != nil {
 		return 0, err
 	}
-
 	return written, nil
 }
-
 func fileHeaderAsByteSlice(compressionType uint32) []byte {
 	// 4 byte version number, 4 byte compression code = 8 bytes
 	bytes := make([]byte, 8)
@@ -88,7 +76,7 @@ func fileHeaderAsByteSlice(compressionType uint32) []byte {
 }
 
 // for legacy reference still around, main paths unused - mostly for tests writing old versions
-//noinspection GoUnusedFunction
+// noinspection GoUnusedFunction
 func writeRecordHeaderV1(writer *FileWriter, payloadSizeUncompressed uint64, payloadSizeCompressed uint64) (int, error) {
 	// 4 byte magic number, 8 byte uncompressed size, 8 bytes for compressed size = 20 bytes
 	bytes := make([]byte, RecordHeaderSizeBytes)
@@ -99,24 +87,20 @@ func writeRecordHeaderV1(writer *FileWriter, payloadSizeUncompressed uint64, pay
 	if err != nil {
 		return 0, err
 	}
-
 	return written, nil
 }
-
 func fillRecordHeaderV2(bytes []byte, payloadSizeUncompressed uint64, payloadSizeCompressed uint64) []byte {
 	off := binary.PutUvarint(bytes, MagicNumberSeparatorLong)
 	off += binary.PutUvarint(bytes[off:], payloadSizeUncompressed)
 	off += binary.PutUvarint(bytes[off:], payloadSizeCompressed)
 	return bytes[:off]
 }
-
 func writeRecordHeaderV2(writer *FileWriter, payloadSizeUncompressed uint64, payloadSizeCompressed uint64) (int, error) {
 	header := fillRecordHeaderV2(writer.recordHeaderCache, payloadSizeUncompressed, payloadSizeCompressed)
 	written, err := writer.bufWriter.Write(header)
 	if err != nil {
 		return 0, err
 	}
-
 	return written, nil
 }
 
@@ -125,15 +109,12 @@ func (w *FileWriter) Write(record []byte) (uint64, error) {
 	if !w.open || w.closed {
 		return 0, errors.New("writer was either not opened yet or is closed already")
 	}
-
 	recordToWrite := record
 	uncompressedSize := uint64(len(recordToWrite))
 	compressedSize := uint64(0)
-
 	if w.compressor != nil {
 		poolBuffer := w.bufferPool.Get(int(uncompressedSize))
 		defer w.bufferPool.Put(poolBuffer)
-
 		compressedRecord, err := w.compressor.CompressWithBuf(recordToWrite, poolBuffer)
 		if err != nil {
 			return 0, fmt.Errorf("failed to compress record in file at '%s' failed with %w", w.file.Name(), err)
@@ -141,22 +122,18 @@ func (w *FileWriter) Write(record []byte) (uint64, error) {
 		recordToWrite = compressedRecord
 		compressedSize = uint64(len(compressedRecord))
 	}
-
 	prevOffset := w.currentOffset
 	headerBytesWritten, err := writeRecordHeaderV2(w, uncompressedSize, compressedSize)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write record header in file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	recordBytesWritten, err := w.bufWriter.Write(recordToWrite)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write record in file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	if recordBytesWritten != len(recordToWrite) {
 		return 0, fmt.Errorf("mismatch in written record len for file '%s', expected %d but were %d", w.file.Name(), recordToWrite, recordBytesWritten)
 	}
-
 	w.currentOffset = prevOffset + uint64(headerBytesWritten) + uint64(recordBytesWritten)
 	return prevOffset, nil
 }
@@ -167,25 +144,20 @@ func (w *FileWriter) WriteSync(record []byte) (uint64, error) {
 	if w.alignedBlockWrites {
 		return 0, DirectIOSyncWriteErr
 	}
-
 	offset, err := w.Write(record)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write record to file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	err = w.bufWriter.Flush()
 	if err != nil {
 		return 0, fmt.Errorf("failed to flush sync in file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	err = w.file.Sync()
 	if err != nil {
 		return 0, fmt.Errorf("failed to sync file at '%s' failed with %w", w.file.Name(), err)
 	}
-
 	return offset, nil
 }
-
 func (w *FileWriter) Close() error {
 	w.closed = true
 	w.open = false
@@ -199,21 +171,18 @@ func (w *FileWriter) Close() error {
 	}
 	return nil
 }
-
 func (w *FileWriter) Size() uint64 {
 	return w.currentOffset
 }
 
 // options
-
 type FileWriterOptions struct {
-	path            string
 	file            *os.File
+	path            string
 	compressionType int
 	bufferSizeBytes int
 	enableDirectIO  bool
 }
-
 type FileWriterOption func(*FileWriterOptions)
 
 // Path defines the file path where to write the recordio file into. Path will create a new file if it doesn't exist yet,
@@ -265,26 +234,21 @@ func NewFileWriter(writerOptions ...FileWriterOption) (WriterI, error) {
 		bufferSizeBytes: DefaultBufferSize,
 		enableDirectIO:  false,
 	}
-
 	for _, writeOption := range writerOptions {
 		writeOption(opts)
 	}
-
 	if (opts.file == nil) == (opts.path == "") {
 		return nil, errors.New("NewFileWriter: either os.File or string path must be supplied, never both")
 	}
-
 	if opts.path == "" {
 		opts.path = opts.file.Name()
 	}
-
 	var factory ReaderWriterCloserFactory
 	if opts.enableDirectIO {
 		factory = DirectIOFactory{}
 	} else {
 		factory = BufferedIOFactory{}
 	}
-
 	// we have to close the passed file handle because we're going to create a new one based on paths
 	if opts.file != nil {
 		err := opts.file.Close()
@@ -292,7 +256,6 @@ func NewFileWriter(writerOptions ...FileWriterOption) (WriterI, error) {
 			return nil, fmt.Errorf("failed to close existing file handle at '%s' failed with %w", opts.path, err)
 		}
 	}
-
 	file, writer, err := factory.CreateNewWriter(opts.path, opts.bufferSizeBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new Writer at '%s' failed with %w", opts.path, err)

--- a/recordio/proto/proto_writer.go
+++ b/recordio/proto/proto_writer.go
@@ -2,11 +2,10 @@ package proto
 
 import (
 	"errors"
-	"os"
-
 	"github.com/ncw/directio"
 	"github.com/thomasjungblut/go-sstables/recordio"
 	"google.golang.org/protobuf/proto"
+	"os"
 )
 
 type Writer struct {
@@ -16,7 +15,6 @@ type Writer struct {
 func (w *Writer) Open() error {
 	return w.writer.Open()
 }
-
 func (w *Writer) Write(record proto.Message) (uint64, error) {
 	bytes, err := proto.Marshal(record)
 	if err != nil {
@@ -24,7 +22,6 @@ func (w *Writer) Write(record proto.Message) (uint64, error) {
 	}
 	return w.writer.Write(bytes)
 }
-
 func (w *Writer) WriteSync(record proto.Message) (uint64, error) {
 	bytes, err := proto.Marshal(record)
 	if err != nil {
@@ -32,25 +29,21 @@ func (w *Writer) WriteSync(record proto.Message) (uint64, error) {
 	}
 	return w.writer.WriteSync(bytes)
 }
-
 func (w *Writer) Close() error {
 	return w.writer.Close()
 }
-
 func (w *Writer) Size() uint64 {
 	return w.writer.Size()
 }
 
 // options
-
 type WriterOptions struct {
-	path            string
 	file            *os.File
+	path            string
 	compressionType int
 	bufSizeBytes    int
 	useDirectIO     bool
 }
-
 type WriterOption func(*WriterOptions)
 
 func Path(p string) WriterOption {
@@ -58,25 +51,21 @@ func Path(p string) WriterOption {
 		args.path = p
 	}
 }
-
 func File(p *os.File) WriterOption {
 	return func(args *WriterOptions) {
 		args.file = p
 	}
 }
-
 func CompressionType(p int) WriterOption {
 	return func(args *WriterOptions) {
 		args.compressionType = p
 	}
 }
-
 func WriteBufferSizeBytes(p int) WriterOption {
 	return func(args *WriterOptions) {
 		args.bufSizeBytes = p
 	}
 }
-
 func DirectIO() WriterOption {
 	return func(args *WriterOptions) {
 		args.useDirectIO = true
@@ -93,15 +82,12 @@ func NewWriter(writerOptions ...WriterOption) (WriterI, error) {
 		bufSizeBytes:    1024 * 1024 * 4,
 		useDirectIO:     false,
 	}
-
 	for _, writeOption := range writerOptions {
 		writeOption(opts)
 	}
-
 	if (opts.file != nil) && (opts.path != "") {
 		return nil, errors.New("either os.File or string path must be supplied, never both")
 	}
-
 	if opts.file == nil {
 		if opts.path == "" {
 			return nil, errors.New("path was not supplied")
@@ -120,7 +106,6 @@ func NewWriter(writerOptions ...WriterOption) (WriterI, error) {
 			opts.file = f
 		}
 	}
-
 	writer, err := recordio.NewFileWriter(
 		recordio.File(opts.file),
 		recordio.CompressionType(opts.compressionType),
@@ -128,6 +113,5 @@ func NewWriter(writerOptions ...WriterOption) (WriterI, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &Writer{writer: writer}, nil
 }

--- a/simpledb/porcupine/db_recorder.go
+++ b/simpledb/porcupine/db_recorder.go
@@ -1,17 +1,15 @@
 package porcupine
 
 import (
-	"time"
-
 	"github.com/anishathalye/porcupine"
 	"github.com/thomasjungblut/go-sstables/simpledb"
+	"time"
 )
 
 type DatabaseClientRecorder struct {
-	clientId int
-	db       simpledb.DatabaseI
-
+	db         simpledb.DatabaseI
 	operations []porcupine.Operation[Input, Output]
+	clientId   int
 }
 
 func NewDatabaseRecorder(db simpledb.DatabaseI, clientId int) *DatabaseClientRecorder {
@@ -21,11 +19,9 @@ func NewDatabaseRecorder(db simpledb.DatabaseI, clientId int) *DatabaseClientRec
 		operations: []porcupine.Operation[Input, Output]{},
 	}
 }
-
 func (d *DatabaseClientRecorder) Operations() []porcupine.Operation[Input, Output] {
 	return d.operations
 }
-
 func (d *DatabaseClientRecorder) Get(key string) (string, error) {
 	start := time.Now()
 	val, err := d.db.Get(key)
@@ -44,10 +40,8 @@ func (d *DatabaseClientRecorder) Get(key string) (string, error) {
 		},
 		Return: end.UnixNano(),
 	})
-
 	return val, err
 }
-
 func (d *DatabaseClientRecorder) Put(key, value string) error {
 	start := time.Now()
 	err := d.db.Put(key, value)
@@ -67,10 +61,8 @@ func (d *DatabaseClientRecorder) Put(key, value string) error {
 		},
 		Return: end.UnixNano(),
 	})
-
 	return err
 }
-
 func (d *DatabaseClientRecorder) Delete(key string) error {
 	start := time.Now()
 	err := d.db.Delete(key)
@@ -90,6 +82,5 @@ func (d *DatabaseClientRecorder) Delete(key string) error {
 		},
 		Return: end.UnixNano(),
 	})
-
 	return err
 }

--- a/simpledb/porcupine/model.go
+++ b/simpledb/porcupine/model.go
@@ -3,13 +3,12 @@ package porcupine
 import (
 	"errors"
 	"fmt"
-	"log"
-	"reflect"
-	"testing"
-
 	pp "github.com/anishathalye/porcupine"
 	"github.com/stretchr/testify/require"
 	"github.com/thomasjungblut/go-sstables/simpledb"
+	"log"
+	"reflect"
+	"testing"
 )
 
 const (
@@ -21,17 +20,15 @@ const (
 type MapState struct {
 	m map[string]string
 }
-
 type Input struct {
-	Operation uint8
 	Key       string
 	Val       string
+	Operation uint8
 }
-
 type Output struct {
+	Err error
 	Key string
 	Val string
-	Err error
 }
 
 func (s MapState) Clone() MapState {
@@ -41,27 +38,22 @@ func (s MapState) Clone() MapState {
 	}
 	return MapState{m: sx}
 }
-
 func (s MapState) Equals(otherState MapState) bool {
 	return reflect.DeepEqual(s.m, otherState.m)
 }
-
 func shorten(s string, size int) string {
 	if len(s) > size {
 		return s[:size]
 	}
 	return s
 }
-
 func (s MapState) String() string {
 	shortValueState := map[string]string{}
 	for k, v := range s.m {
 		shortValueState[k] = shorten(v, 5)
 	}
-
 	return fmt.Sprintf("%v", shortValueState)
 }
-
 func NewMapState() MapState {
 	return MapState{m: map[string]string{}}
 }
@@ -85,7 +77,6 @@ var Model = pp.Model[MapState, Input, Output]{
 	},
 	Step: func(s MapState, i Input, o Output) (bool, MapState) {
 		stateVal, found := s.m[i.Key]
-
 		switch i.Operation {
 		case GetOp:
 			if errors.Is(o.Err, simpledb.ErrNotFound) {
@@ -107,12 +98,10 @@ var Model = pp.Model[MapState, Input, Output]{
 			}
 			break
 		}
-
 		if o.Err != nil {
 			log.Printf("unexpected error state found for key: [%s] %v\n", i.Key, o.Err)
 			panic(o.Err)
 		}
-
 		return false, s
 	},
 	DescribeOperation: func(i Input, o Output) string {
@@ -128,7 +117,6 @@ var Model = pp.Model[MapState, Input, Output]{
 			opName = "Del"
 			break
 		}
-
 		return fmt.Sprintf("%s(%s) -> %s", opName, i.Key, shorten(o.Val, 5))
 	},
 }

--- a/sstables/sstable_merger.go
+++ b/sstables/sstable_merger.go
@@ -8,10 +8,9 @@ import (
 )
 
 type ReduceFunc func([]byte, [][]byte, []int) ([]byte, []byte)
-
 type SSTableMergeIteratorContext struct {
-	ctx      int
 	iterator SSTableIteratorI
+	ctx      int
 }
 
 func (s SSTableMergeIteratorContext) Next() ([]byte, []byte, error) {
@@ -21,11 +20,9 @@ func (s SSTableMergeIteratorContext) Next() ([]byte, []byte, error) {
 	}
 	return k, v, nil
 }
-
 func (s SSTableMergeIteratorContext) Context() int {
 	return s.ctx
 }
-
 func NewMergeIteratorContext(context int, iterator SSTableIteratorI) SSTableMergeIteratorContext {
 	return SSTableMergeIteratorContext{
 		ctx:      context,
@@ -47,7 +44,6 @@ func (m SSTableMerger) Merge(iterators []SSTableMergeIteratorContext, writer SST
 	if err != nil {
 		return fmt.Errorf("merge error while initializing the heap: %w", err)
 	}
-
 	for {
 		k, v, _, err := pqq.Next()
 		if err != nil {
@@ -57,13 +53,11 @@ func (m SSTableMerger) Merge(iterators []SSTableMergeIteratorContext, writer SST
 				return fmt.Errorf("merge error during heap next: %w", err)
 			}
 		}
-
 		err = writer.WriteNext(k, v)
 		if err != nil {
 			return fmt.Errorf("merge error while writing next record: %w", err)
 		}
 	}
-
 	return nil
 }
 
@@ -94,7 +88,6 @@ func (m *MergeCompactionIterator) Next() ([]byte, []byte, error) {
 				return nil, nil, err
 			}
 		}
-
 		var toReturnKey, toReturnVal []byte
 		//we have to accumulate the whole sequence
 		if m.prevKey != nil && m.comp.Compare(k, m.prevKey) != 0 {
@@ -106,17 +99,14 @@ func (m *MergeCompactionIterator) Next() ([]byte, []byte, error) {
 			m.valBuf = make([][]byte, 0)
 			m.ctxBuf = make([]int, 0)
 		}
-
 		m.prevKey = k
 		m.valBuf = append(m.valBuf, v)
 		m.ctxBuf = append(m.ctxBuf, c)
-
 		if toReturnKey != nil && toReturnVal != nil {
 			return toReturnKey, toReturnVal, nil
 		}
 	}
 }
-
 func (m SSTableMerger) MergeCompactIterator(iterators []SSTableMergeIteratorContext, reduce ReduceFunc) (SSTableIteratorI, error) {
 	var iteratorWithContext []pq.IteratorWithContext[[]byte, []byte, int]
 	for _, iterator := range iterators {
@@ -126,11 +116,9 @@ func (m SSTableMerger) MergeCompactIterator(iterators []SSTableMergeIteratorCont
 	if err != nil {
 		return nil, fmt.Errorf("merge compact error while initializing the heap: %w", err)
 	}
-
 	var prevKey []byte
 	valBuf := make([][]byte, 0)
 	ctxBuf := make([]int, 0)
-
 	return &MergeCompactionIterator{
 		comp:    m.comp,
 		reduce:  reduce,
@@ -139,7 +127,6 @@ func (m SSTableMerger) MergeCompactIterator(iterators []SSTableMergeIteratorCont
 		valBuf:  valBuf,
 		ctxBuf:  ctxBuf,
 	}, nil
-
 }
 
 // MergeCompact accepts a slice of sstable iterators to merge into an already opened writer. The caller needs to close the writer.
@@ -148,7 +135,6 @@ func (m SSTableMerger) MergeCompact(iterators []SSTableMergeIteratorContext, wri
 	if err != nil {
 		return fmt.Errorf("merge compact error while initializing the iterator: %w", err)
 	}
-
 	for {
 		k, v, err := iterator.Next()
 		if err != nil {
@@ -160,10 +146,8 @@ func (m SSTableMerger) MergeCompact(iterators []SSTableMergeIteratorContext, wri
 		}
 		err = writer.WriteNext(k, v)
 	}
-
 	return nil
 }
-
 func NewSSTableMerger(comp skiplist.Comparator[[]byte]) SSTableMerger {
 	return SSTableMerger{comp}
 }

--- a/sstables/sstable_writer.go
+++ b/sstables/sstable_writer.go
@@ -3,33 +3,28 @@ package sstables
 import (
 	"errors"
 	"fmt"
-	"hash/fnv"
-	"os"
-	"path/filepath"
-
 	"github.com/steakknife/bloomfilter"
 	"github.com/thomasjungblut/go-sstables/recordio"
 	rProto "github.com/thomasjungblut/go-sstables/recordio/proto"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	sProto "github.com/thomasjungblut/go-sstables/sstables/proto"
 	"google.golang.org/protobuf/proto"
+	"hash/fnv"
+	"os"
+	"path/filepath"
 )
 
 type SSTableStreamWriter struct {
-	opts *SSTableWriterOptions
-
+	opts          *SSTableWriterOptions
 	indexFilePath string
 	dataFilePath  string
 	metaFilePath  string
-
-	indexWriter  rProto.WriterI
-	dataWriter   recordio.WriterI
-	metaDataFile *os.File
-
-	bloomFilter *bloomfilter.Filter
-	metaData    *sProto.MetaData
-
-	lastKey []byte
+	indexWriter   rProto.WriterI
+	dataWriter    recordio.WriterI
+	metaDataFile  *os.File
+	bloomFilter   *bloomfilter.Filter
+	metaData      *sProto.MetaData
+	lastKey       []byte
 }
 
 func (writer *SSTableStreamWriter) Open() error {
@@ -42,12 +37,10 @@ func (writer *SSTableStreamWriter) Open() error {
 		return fmt.Errorf("error while creating index writer in '%s': %w", writer.opts.basePath, err)
 	}
 	writer.indexWriter = iWriter
-
 	err = writer.indexWriter.Open()
 	if err != nil {
 		return fmt.Errorf("error while opening index writer in '%s': %w", writer.opts.basePath, err)
 	}
-
 	writer.dataFilePath = filepath.Join(writer.opts.basePath, DataFileName)
 	dWriter, err := recordio.NewFileWriter(
 		recordio.Path(writer.dataFilePath),
@@ -56,14 +49,12 @@ func (writer *SSTableStreamWriter) Open() error {
 	if err != nil {
 		return fmt.Errorf("error while creating data writer in '%s': %w", writer.opts.basePath, err)
 	}
-
 	// TODO(thomas): if any of these open fails, we should try to at least close the ones we already have opened
 	writer.dataWriter = dWriter
 	err = writer.dataWriter.Open()
 	if err != nil {
 		return fmt.Errorf("error while opening data writer in '%s': %w", writer.opts.basePath, err)
 	}
-
 	writer.metaFilePath = filepath.Join(writer.opts.basePath, MetaFileName)
 	metaFile, err := os.OpenFile(writer.metaFilePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
@@ -73,7 +64,6 @@ func (writer *SSTableStreamWriter) Open() error {
 	writer.metaData = &sProto.MetaData{
 		Version: Version,
 	}
-
 	if writer.opts.enableBloomFilter {
 		bf, err := bloomfilter.NewOptimal(writer.opts.bloomExpectedNumberOfElements, writer.opts.bloomFpProbability)
 		if err != nil {
@@ -81,10 +71,8 @@ func (writer *SSTableStreamWriter) Open() error {
 		}
 		writer.bloomFilter = bf
 	}
-
 	return nil
 }
-
 func (writer *SSTableStreamWriter) WriteNext(key []byte, value []byte) error {
 	if writer.lastKey != nil {
 		cmpResult := writer.opts.keyComparator.Compare(writer.lastKey, key)
@@ -93,7 +81,6 @@ func (writer *SSTableStreamWriter) WriteNext(key []byte, value []byte) error {
 		} else if cmpResult > 0 {
 			return fmt.Errorf("sstables.WriteNext '%s': non-ascending key cannot be written", writer.opts.basePath)
 		}
-
 		// the size of the key may be variable, that's why we might allocate a new buffer for the last key
 		if len(writer.lastKey) != len(key) {
 			writer.lastKey = make([]byte, len(key))
@@ -102,50 +89,39 @@ func (writer *SSTableStreamWriter) WriteNext(key []byte, value []byte) error {
 		if writer.metaData == nil {
 			return fmt.Errorf("sstables.writeNext '%s': no metadata available to write into, table might not be opened yet", writer.opts.basePath)
 		}
-
 		writer.metaData.MinKey = make([]byte, len(key))
 		writer.lastKey = make([]byte, len(key))
 		copy(writer.metaData.MinKey, key)
 	}
-
 	copy(writer.lastKey, key)
-
 	if writer.opts.enableBloomFilter {
 		fnvHash := fnv.New64()
 		_, _ = fnvHash.Write(key)
 		writer.bloomFilter.Add(fnvHash)
 	}
-
 	recordOffset, err := writer.dataWriter.Write(value)
 	if err != nil {
 		return fmt.Errorf("error writeNext data writer error in '%s': %w", writer.opts.basePath, err)
 	}
-
 	_, err = writer.indexWriter.Write(&sProto.IndexEntry{Key: key, ValueOffset: recordOffset})
 	if err != nil {
 		return fmt.Errorf("error writeNext index writer error in '%s': %w", writer.opts.basePath, err)
 	}
-
 	writer.metaData.NumRecords += 1
-
 	return nil
 }
-
 func (writer *SSTableStreamWriter) Close() (err error) {
 	err = errors.Join(writer.indexWriter.Close(), writer.dataWriter.Close())
-
 	if writer.opts.enableBloomFilter && writer.bloomFilter != nil {
 		_, bErr := writer.bloomFilter.WriteFile(filepath.Join(writer.opts.basePath, BloomFileName))
 		if bErr != nil {
 			err = errors.Join(err, fmt.Errorf("error in writing bloom filter  in '%s': %w", writer.opts.basePath, bErr))
 		}
 	}
-
 	if writer.metaData != nil && writer.metaDataFile != nil {
 		defer func() {
 			err = errors.Join(err, writer.metaDataFile.Close())
 		}()
-
 		writer.metaData.MaxKey = writer.lastKey
 		writer.metaData.DataBytes = writer.dataWriter.Size()
 		writer.metaData.IndexBytes = writer.indexWriter.Size()
@@ -154,13 +130,11 @@ func (writer *SSTableStreamWriter) Close() (err error) {
 		if mErr != nil {
 			return errors.Join(err, fmt.Errorf("error in serializing metadata in '%s': %w", writer.opts.basePath, mErr))
 		}
-
 		_, wErr := writer.metaDataFile.Write(bytes)
 		if wErr != nil {
 			return errors.Join(err, fmt.Errorf("error in writing metadata in '%s': %w", writer.opts.basePath, wErr))
 		}
 	}
-
 	return err
 }
 
@@ -173,11 +147,9 @@ func (writer *SSTableSimpleWriter) WriteSkipListMap(skipListMap skiplist.MapI[[]
 	if err != nil {
 		return err
 	}
-
 	defer func() {
 		err = errors.Join(err, writer.streamWriter.Close())
 	}()
-
 	it, _ := skipListMap.Iterator()
 	for {
 		k, v, err := it.Next()
@@ -187,13 +159,11 @@ func (writer *SSTableSimpleWriter) WriteSkipListMap(skipListMap skiplist.MapI[[]
 		if err != nil {
 			return fmt.Errorf("error in getting next skiplist record in '%s': %w", writer.streamWriter.opts.basePath, err)
 		}
-
 		err = writer.streamWriter.WriteNext(k, v)
 		if err != nil {
 			return fmt.Errorf("error in writing skiplist record in '%s': %w", writer.streamWriter.opts.basePath, err)
 		}
 	}
-
 	return nil
 }
 
@@ -210,27 +180,21 @@ func NewSSTableStreamWriter(writerOptions ...WriterOption) (*SSTableStreamWriter
 		writeBufferSizeBytes:          1024 * 1024 * 4,
 		keyComparator:                 nil,
 	}
-
 	for _, writeOption := range writerOptions {
 		writeOption(opts)
 	}
-
 	if opts.basePath == "" {
 		return nil, errors.New("basePath was not supplied")
 	}
-
 	if opts.keyComparator == nil {
 		return nil, errors.New("no key comparator supplied")
 	}
-
 	if opts.bloomExpectedNumberOfElements <= 0 {
 		return nil, fmt.Errorf("unexpected number of bloom filter elements, was: %d",
 			opts.bloomExpectedNumberOfElements)
 	}
-
 	return &SSTableStreamWriter{opts: opts}, nil
 }
-
 func NewSSTableSimpleWriter(writerOptions ...WriterOption) (*SSTableSimpleWriter, error) {
 	writerOptions = append(writerOptions, WriteBufferSizeBytes(4096))
 	writer, err := NewSSTableStreamWriter(writerOptions...)
@@ -241,18 +205,16 @@ func NewSSTableSimpleWriter(writerOptions ...WriterOption) (*SSTableSimpleWriter
 }
 
 // options
-
 type SSTableWriterOptions struct {
+	keyComparator                 skiplist.Comparator[[]byte]
 	basePath                      string
 	indexCompressionType          int
 	dataCompressionType           int
-	enableBloomFilter             bool
 	bloomExpectedNumberOfElements uint64
 	bloomFpProbability            float64
 	writeBufferSizeBytes          int
-	keyComparator                 skiplist.Comparator[[]byte]
+	enableBloomFilter             bool
 }
-
 type WriterOption func(*SSTableWriterOptions)
 
 func WriteBasePath(p string) WriterOption {
@@ -260,43 +222,36 @@ func WriteBasePath(p string) WriterOption {
 		args.basePath = p
 	}
 }
-
 func IndexCompressionType(p int) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.indexCompressionType = p
 	}
 }
-
 func DataCompressionType(p int) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.dataCompressionType = p
 	}
 }
-
 func EnableBloomFilter() WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.enableBloomFilter = true
 	}
 }
-
 func BloomExpectedNumberOfElements(n uint64) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.bloomExpectedNumberOfElements = n
 	}
 }
-
 func BloomFalsePositiveProbability(fpProbability float64) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.bloomFpProbability = fpProbability
 	}
 }
-
 func WriteBufferSizeBytes(bufSizeBytes int) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.writeBufferSizeBytes = bufSizeBytes
 	}
 }
-
 func WithKeyComparator(cmp skiplist.Comparator[[]byte]) WriterOption {
 	return func(args *SSTableWriterOptions) {
 		args.keyComparator = cmp

--- a/wal/write_ahead_log.go
+++ b/wal/write_ahead_log.go
@@ -2,18 +2,15 @@ package wal
 
 import (
 	"errors"
-
 	"github.com/thomasjungblut/go-sstables/recordio"
 )
 
 const DefaultMaxWalSize uint64 = 128 * 1024 * 1024 // 128mb
-
 type WriteAheadLogReplayI interface {
 	// Replay the whole WAL from start, calling the given process function
 	// for each record in guaranteed order.
 	Replay(process func(record []byte) error) error
 }
-
 type WriteAheadLogAppendI interface {
 	recordio.CloseableI
 	// Append a given record and does NOT execute fsync to guarantee the persistence of the record.
@@ -21,29 +18,24 @@ type WriteAheadLogAppendI interface {
 	// AppendSync a given record and execute fsync to guarantee the persistence of the record.
 	// Has considerably less throughput than Append.
 	AppendSync(record []byte) error
-
 	// Rotate - The WAL usually auto-rotates after a certain size - this method allows to force this rotation.
 	// This can be useful in scenarios where you want to flush a memstore and rotate the WAL at the same time.
 	// Therefore, this returns the path of the previous wal file that was closed through this operation.
 	Rotate() (string, error)
 }
-
 type WriteAheadLogCleanI interface {
 	// Clean Removes all WAL files and the directory it is contained in
 	Clean() error
 }
-
 type WriteAheadLogCompactI interface {
 	// Compact should compact the WAL, but isn't properly implemented just yet
 	Compact() error
 }
-
 type WriteAheadLogI interface {
 	WriteAheadLogAppendI
 	WriteAheadLogReplayI
 	WriteAheadLogCleanI
 }
-
 type WriteAheadLog struct {
 	WriteAheadLogAppendI
 	WriteAheadLogReplayI
@@ -79,29 +71,24 @@ func NewWriteAheadLogOptions(walOptions ...Option) (*Options, error) {
 			return recordio.NewFileReaderWithPath(path)
 		},
 	}
-
 	for _, walOption := range walOptions {
 		walOption(opts)
 	}
-
 	if opts.basePath == "" {
 		return nil, errors.New("basePath was not supplied")
 	}
-
 	return opts, nil
 }
 
 // options
-
 type Options struct {
-	maxWalFileSize uint64
-	basePath       string
 	// TODO(thomas): this should be ideally in a writer-only option
 	writerFactory func(path string) (recordio.WriterI, error)
 	// TODO(thomas): this should be ideally in a reader-only option
-	readerFactory func(path string) (recordio.ReaderI, error)
+	readerFactory  func(path string) (recordio.ReaderI, error)
+	basePath       string
+	maxWalFileSize uint64
 }
-
 type Option func(*Options)
 
 func BasePath(p string) Option {
@@ -109,19 +96,16 @@ func BasePath(p string) Option {
 		args.basePath = p
 	}
 }
-
 func MaximumWalFileSizeBytes(p uint64) Option {
 	return func(args *Options) {
 		args.maxWalFileSize = p
 	}
 }
-
 func WriterFactory(writerFactory func(path string) (recordio.WriterI, error)) Option {
 	return func(args *Options) {
 		args.writerFactory = writerFactory
 	}
 }
-
 func ReaderFactory(readerFactory func(path string) (recordio.ReaderI, error)) Option {
 	return func(args *Options) {
 		args.readerFactory = readerFactory


### PR DESCRIPTION
```
$ betteralign -apply ./...
/skiplist/map_generic.go:138:24: 16 bytes saved: struct with 40 pointer bytes could be 24
/pq/priority_queue.go:27:37: 8 bytes saved: struct with 56 pointer bytes could be 48
/pq/priority_queue.go:34:43: 24 bytes saved: struct with 48 pointer bytes could be 24
/recordio/bufio_vendor.go:23:13: 24 bytes saved: struct with 64 pointer bytes could be 40
/recordio/bufio_vendor.go:129:13: 32 bytes saved: struct with 72 pointer bytes could be 40
/recordio/common_reader.go:11:13: 8 bytes saved: struct with 24 pointer bytes could be 16
/recordio/file_reader.go:12:17: 16 bytes saved: struct with 56 pointer bytes could be 40
/recordio/file_writer.go:21:17: 8 bytes saved: struct of size 104 could be 96
/recordio/file_writer.go:209:24: 8 bytes saved: struct with 24 pointer bytes could be 16
/recordio/mmap_reader.go:12:17: 8 bytes saved: struct with 40 pointer bytes could be 32
/recordio/proto/proto_writer.go:46:20: 8 bytes saved: struct with 24 pointer bytes could be 16
/sstables/sstable_merger.go:12:34: 8 bytes saved: struct with 24 pointer bytes could be 16
/sstables/sstable_reader.go:296:27: 8 bytes saved: struct with 32 pointer bytes could be 24
/sstables/sstable_writer.go:245:27: 56 bytes saved: struct with 80 pointer bytes could be 24
/sstables/super_sstable_reader.go:12:25: 16 bytes saved: struct with 40 pointer bytes could be 24
/memstore/memstore.go:62:15: 8 bytes saved: struct of size 32 could be 24
/wal/appender.go:13:15: 16 bytes saved: struct with 64 pointer bytes could be 48
/wal/write_ahead_log.go:96:14: 16 bytes saved: struct with 40 pointer bytes could be 24
/simpledb/db.go:63:9: 56 bytes saved: struct with 176 pointer bytes could be 120
/simpledb/sstable_manager.go:15:21: 16 bytes saved: struct with 88 pointer bytes could be 72
/simpledb/porcupine/db_recorder.go:10:29: 8 bytes saved: struct with 32 pointer bytes could be 24
/simpledb/porcupine/model.go:25:12: 8 bytes saved: struct with 32 pointer bytes could be 24
/simpledb/porcupine/model.go:31:13: 8 bytes saved: struct with 48 pointer bytes could be 40
```