### PR TITLE
Fix compaction with holes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,4 @@ require (
 
 replace github.com/anishathalye/porcupine v0.1.2 => github.com/tjungblu/porcupine v0.0.0-20221116095144-377185aa0569
 
-go 1.22
+go 1.23

--- a/simpledb/compaction.go
+++ b/simpledb/compaction.go
@@ -116,11 +116,8 @@ func executeCompaction(db *DB) (compactionMetadata *proto.CompactionMetadata, er
 		}
 	}()
 
-	// we need to keep it if the sstable is not the first with this key.
-	// SS1(KEY1=toto) SS2(KEY2=deleted)  in this case the KEY2 can be removed in SS2
-	// SS1(KEY2=toto) SS2(KEY2=deleted)  in this case the KEY2 can't be removed in SS2
-
-	err = sstables.NewSSTableMerger(db.cmp).MergeCompact(iterators, writer, sstables.ScanReduceLatestWins)
+	reduceFunc := sstables.ScanReduceLatestWinsSkipTombstones
+	err = sstables.NewSSTableMerger(db.cmp).MergeCompact(iterators, writer, reduceFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/simpledb/compaction.go
+++ b/simpledb/compaction.go
@@ -58,7 +58,7 @@ func executeCompaction(db *DB) (compactionMetadata *proto.CompactionMetadata, er
 	compactionAction := db.sstableManager.candidateTablesForCompaction(db.compactedMaxSizeBytes)
 	paths := compactionAction.pathsToCompact
 	numRecords := compactionAction.totalRecords
-	if len(paths) <= db.compactionThreshold {
+	if len(paths) <= db.compactionFileThreshold {
 		return nil, nil
 	}
 

--- a/simpledb/compaction_test.go
+++ b/simpledb/compaction_test.go
@@ -81,6 +81,17 @@ func writeSSTableWithTombstoneInDatabaseFolder(t *testing.T, db *DB, p string) {
 	))
 }
 
+func writeEmptySSTableInDatabaseFolder(t *testing.T, db *DB, p string) {
+	fakeTablePath := filepath.Join(db.basePath, p)
+	assert.Nil(t, os.MkdirAll(fakeTablePath, 0700))
+	mStore := memstore.NewMemStore()
+
+	assert.Nil(t, mStore.FlushWithTombstones(
+		sstables.WriteBasePath(fakeTablePath),
+		sstables.WithKeyComparator(db.cmp),
+	))
+}
+
 func TestExecCompactionWithTombstone(t *testing.T) {
 	db := newOpenedSimpleDB(t, "simpledb_compactionSameContent")
 	defer cleanDatabaseFolder(t, db)
@@ -141,4 +152,37 @@ func TestExecCompactionWithTombstoneRewriten(t *testing.T) {
 
 	// check size of compacted sstable
 	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+}
+
+// regression reported in https://github.com/thomasjungblut/go-sstables/issues/36
+func TestExecCompactionWithTombstonesEmptyTable(t *testing.T) {
+	db := newOpenedSimpleDB(t, "simpledb_compactionEmptyTable")
+	defer cleanDatabaseFolder(t, db)
+	// we'll close the database to mock some internals directly, yes it's very hacky
+	closeDatabase(t, db)
+	db.closed = false
+	db.compactionThreshold = 0
+
+	writeEmptySSTableInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 41))
+	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
+	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
+	assert.Nil(t, db.reconstructSSTables())
+	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
+
+	compactionMeta, err := executeCompaction(db)
+	assert.Nil(t, err)
+	assert.Equal(t, "sstable_000000000000041", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000041", "sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
+	fmt.Print(compactionMeta)
+	err = db.sstableManager.reflectCompactionResult(compactionMeta)
+	assert.NoError(t, err)
+	v, err := db.Get("512")
+	assert.NoError(t, err)
+	assert.Equal(t, "512", v)
+	// for cleanups
+	assert.Nil(t, db.sstableManager.currentReader.Close())
+
+	// check size of compacted sstable
+	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+
 }

--- a/simpledb/compaction_test.go
+++ b/simpledb/compaction_test.go
@@ -17,7 +17,7 @@ func TestExecCompactionLessFilesThanExpected(t *testing.T) {
 	defer cleanDatabaseFolder(t, db)
 	defer closeDatabase(t, db)
 
-	db.compactionThreshold = 1
+	db.compactionFileThreshold = 1
 	db.sstableManager.addReader(&MockSSTableReader{
 		metadata: &proto.MetaData{NumRecords: 10, TotalBytes: 100},
 		path:     "1",
@@ -34,7 +34,7 @@ func TestExecCompactionSameContent(t *testing.T) {
 	// we'll close the database to mock some internals directly, yes it's very hacky
 	closeDatabase(t, db)
 	db.closed = false
-	db.compactionThreshold = 1
+	db.compactionFileThreshold = 1
 
 	writeSSTableInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
 	writeSSTableInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
@@ -53,11 +53,141 @@ func TestExecCompactionSameContent(t *testing.T) {
 	assert.Nil(t, db.sstableManager.currentReader.Close())
 }
 
+func TestExecCompactionWithTombstone(t *testing.T) {
+	db := newOpenedSimpleDB(t, "simpledb_compactionSameContent")
+	defer cleanDatabaseFolder(t, db)
+	closeDatabase(t, db)
+	db.closed = false
+	db.compactionFileThreshold = 0
+
+	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
+	// only one SStable with holes should shrink
+	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
+	assert.Nil(t, db.reconstructSSTables())
+	// 1000 initial + 300 Tombstone on second table
+	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
+
+	compactionMeta, err := executeCompaction(db)
+	assert.Nil(t, err)
+	assert.Equal(t, "sstable_000000000000042", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
+
+	err = db.sstableManager.reflectCompactionResult(compactionMeta)
+	assert.NoError(t, err)
+	v, err := db.Get("512")
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Equal(t, "", v)
+	// for cleanups
+	assert.Nil(t, db.sstableManager.currentReader.Close())
+
+	// check size of compacted sstable
+	assert.Equal(t, 700, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+}
+func TestExecCompactionWithTombstoneRewritten(t *testing.T) {
+	db := newOpenedSimpleDB(t, "simpledb_compactionSameContent")
+	defer cleanDatabaseFolder(t, db)
+	closeDatabase(t, db)
+	db.closed = false
+	db.compactionFileThreshold = 0
+
+	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
+	// the tombstone will be overwritten
+	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
+	assert.Nil(t, db.reconstructSSTables())
+	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
+
+	compactionMeta, err := executeCompaction(db)
+	assert.Nil(t, err)
+	assert.Equal(t, "sstable_000000000000042", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
+
+	err = db.sstableManager.reflectCompactionResult(compactionMeta)
+	assert.NoError(t, err)
+	v, err := db.Get("512")
+	assert.NoError(t, err)
+	assert.Equal(t, "512", v)
+	// for cleanups
+	assert.Nil(t, db.sstableManager.currentReader.Close())
+
+	// check size of compacted sstable
+	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+}
+
+// regression reported in https://github.com/thomasjungblut/go-sstables/issues/36
+func TestExecCompactionWithTombstonesEmptyTable(t *testing.T) {
+	db := newOpenedSimpleDB(t, "simpledb_compactionEmptyTable")
+	defer cleanDatabaseFolder(t, db)
+	closeDatabase(t, db)
+	db.closed = false
+	db.compactionFileThreshold = 0
+
+	writeEmptySSTableInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 41))
+	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
+	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
+	assert.Nil(t, db.reconstructSSTables())
+	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
+
+	compactionMeta, err := executeCompaction(db)
+	assert.Nil(t, err)
+	assert.Equal(t, "sstable_000000000000041", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000041", "sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
+
+	err = db.sstableManager.reflectCompactionResult(compactionMeta)
+	assert.NoError(t, err)
+	v, err := db.Get("512")
+	assert.NoError(t, err)
+	assert.Equal(t, "512", v)
+	// for cleanups
+	assert.Nil(t, db.sstableManager.currentReader.Close())
+
+	// check size of compacted sstable
+	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+}
+
+// regression reported in https://github.com/thomasjungblut/go-sstables/issues/36
+// more specifically this relates to a case where the first table is above the compaction threshold and never compacted.
+// The keyspace might already be partially rewritten, thus wasting unnecessary space.
+// This test is supposed to fail for later changes, thus the assertion is inverted
+func TestCompactionWithTombstonesBeyondMaxSize(t *testing.T) {
+	db := newOpenedSimpleDB(t, "simpledb_compactionTombstoneBeyondMaxSize")
+	defer cleanDatabaseFolder(t, db)
+	closeDatabase(t, db)
+	db.closed = false
+	db.compactionFileThreshold = 0
+	// the tombstone file is about 6k, the 10 written entries are 300k
+	db.compactedMaxSizeBytes = 1024
+
+	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
+	writeSSTableWithDataInDatabaseFolderRange(t, db, fmt.Sprintf(SSTablePattern, 43), 510, 520)
+	assert.Nil(t, db.reconstructSSTables())
+	assert.Equal(t, 310, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
+
+	compactionMeta, err := executeCompaction(db)
+	assert.Nil(t, err)
+	// TODO(thomas): this should also compact the 42 table, as it wastes a ton of space in tombstones
+	assert.Equal(t, "sstable_000000000000043", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000043"}, compactionMeta.SstablePaths)
+
+	err = db.sstableManager.reflectCompactionResult(compactionMeta)
+	assert.NoError(t, err)
+	v, err := db.Get("512")
+	assert.NoError(t, err)
+	assert.Equal(t, "512", v)
+	// for cleanups
+	assert.Nil(t, db.sstableManager.currentReader.Close())
+	// TODO(thomas): ideally that table should only be 10
+	assert.Equal(t, 310, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+}
+
 func writeSSTableWithDataInDatabaseFolder(t *testing.T, db *DB, p string) {
+	writeSSTableWithDataInDatabaseFolderRange(t, db, p, 0, 1000)
+}
+
+func writeSSTableWithDataInDatabaseFolderRange(t *testing.T, db *DB, p string, start, end int) {
 	fakeTablePath := filepath.Join(db.basePath, p)
 	assert.Nil(t, os.MkdirAll(fakeTablePath, 0700))
 	mStore := memstore.NewMemStore()
-	for i := 0; i < 1000; i++ {
+	for i := start; i < end; i++ {
 		assert.Nil(t, mStore.Add([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("%d", i))))
 	}
 	assert.Nil(t, mStore.Flush(
@@ -90,99 +220,4 @@ func writeEmptySSTableInDatabaseFolder(t *testing.T, db *DB, p string) {
 		sstables.WriteBasePath(fakeTablePath),
 		sstables.WithKeyComparator(db.cmp),
 	))
-}
-
-func TestExecCompactionWithTombstone(t *testing.T) {
-	db := newOpenedSimpleDB(t, "simpledb_compactionSameContent")
-	defer cleanDatabaseFolder(t, db)
-	// we'll close the database to mock some internals directly, yes it's very hacky
-	closeDatabase(t, db)
-	db.closed = false
-	db.compactionThreshold = 0
-
-	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
-	// only one SStable with holes should shrink
-	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
-	assert.Nil(t, db.reconstructSSTables())
-	// 1000 initial + 300 Tombstone on second table
-	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
-
-	compactionMeta, err := executeCompaction(db)
-	assert.Nil(t, err)
-	assert.Equal(t, "sstable_000000000000042", compactionMeta.ReplacementPath)
-	assert.Equal(t, []string{"sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
-	fmt.Print(compactionMeta)
-	err = db.sstableManager.reflectCompactionResult(compactionMeta)
-	assert.NoError(t, err)
-	v, err := db.Get("512")
-	assert.ErrorIs(t, err, ErrNotFound)
-	assert.Equal(t, "", v)
-	// for cleanups
-	assert.Nil(t, db.sstableManager.currentReader.Close())
-
-	// check size of compacted sstable
-	assert.Equal(t, 700, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
-}
-func TestExecCompactionWithTombstoneRewriten(t *testing.T) {
-	db := newOpenedSimpleDB(t, "simpledb_compactionSameContent")
-	defer cleanDatabaseFolder(t, db)
-	// we'll close the database to mock some internals directly, yes it's very hacky
-	closeDatabase(t, db)
-	db.closed = false
-	db.compactionThreshold = 0
-
-	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
-	// the tombstone are overwrite
-	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
-	assert.Nil(t, db.reconstructSSTables())
-	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
-
-	compactionMeta, err := executeCompaction(db)
-	assert.Nil(t, err)
-	assert.Equal(t, "sstable_000000000000042", compactionMeta.ReplacementPath)
-	assert.Equal(t, []string{"sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
-	fmt.Print(compactionMeta)
-	err = db.sstableManager.reflectCompactionResult(compactionMeta)
-	assert.NoError(t, err)
-	v, err := db.Get("512")
-	assert.NoError(t, err)
-	assert.Equal(t, "512", v)
-	// for cleanups
-	assert.Nil(t, db.sstableManager.currentReader.Close())
-
-	// check size of compacted sstable
-	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
-}
-
-// regression reported in https://github.com/thomasjungblut/go-sstables/issues/36
-func TestExecCompactionWithTombstonesEmptyTable(t *testing.T) {
-	db := newOpenedSimpleDB(t, "simpledb_compactionEmptyTable")
-	defer cleanDatabaseFolder(t, db)
-	// we'll close the database to mock some internals directly, yes it's very hacky
-	closeDatabase(t, db)
-	db.closed = false
-	db.compactionThreshold = 0
-
-	writeEmptySSTableInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 41))
-	writeSSTableWithTombstoneInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 42))
-	writeSSTableWithDataInDatabaseFolder(t, db, fmt.Sprintf(SSTablePattern, 43))
-	assert.Nil(t, db.reconstructSSTables())
-	assert.Equal(t, 1300, int(db.sstableManager.currentSSTable().MetaData().GetNumRecords()))
-
-	compactionMeta, err := executeCompaction(db)
-	assert.Nil(t, err)
-	assert.Equal(t, "sstable_000000000000041", compactionMeta.ReplacementPath)
-	assert.Equal(t, []string{"sstable_000000000000041", "sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
-	fmt.Print(compactionMeta)
-	err = db.sstableManager.reflectCompactionResult(compactionMeta)
-	assert.NoError(t, err)
-	v, err := db.Get("512")
-	assert.NoError(t, err)
-	assert.Equal(t, "512", v)
-	// for cleanups
-	assert.Nil(t, db.sstableManager.currentReader.Close())
-
-	// check size of compacted sstable
-	assert.Equal(t, 1000, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
-
 }

--- a/simpledb/db.go
+++ b/simpledb/db.go
@@ -67,18 +67,18 @@ type DB struct {
 	// read more here: https://pkg.go.dev/sync/atomic#pkg-note-BUG
 	currentGeneration uint64
 
-	cmp                   skiplist.Comparator[[]byte]
-	basePath              string
-	currentSSTablePath    string
-	memstoreMaxSize       uint64
-	compactionThreshold   int
-	compactionInterval    time.Duration
-	compactedMaxSizeBytes uint64
-	enableCompactions     bool
-	enableAsyncWAL        bool
-	enableDirectIOWAL     bool
-	open                  bool
-	closed                bool
+	cmp                     skiplist.Comparator[[]byte]
+	basePath                string
+	currentSSTablePath      string
+	memstoreMaxSize         uint64
+	compactionFileThreshold int
+	compactionInterval      time.Duration
+	compactedMaxSizeBytes   uint64
+	enableCompactions       bool
+	enableAsyncWAL          bool
+	enableDirectIOWAL       bool
+	open                    bool
+	closed                  bool
 
 	rwLock         *sync.RWMutex
 	wal            wal.WriteAheadLogI
@@ -355,7 +355,7 @@ func NewSimpleDB(basePath string, extraOptions ...ExtraOption) (*DB, error) {
 		basePath:                    basePath,
 		currentSSTablePath:          "",
 		memstoreMaxSize:             extraOpts.memstoreSizeBytes,
-		compactionThreshold:         extraOpts.compactionFileThreshold,
+		compactionFileThreshold:     extraOpts.compactionFileThreshold,
 		compactedMaxSizeBytes:       extraOpts.compactionMaxSizeBytes,
 		enableCompactions:           extraOpts.enableCompactions,
 		enableAsyncWAL:              extraOpts.enableAsyncWAL,

--- a/simpledb/db.go
+++ b/simpledb/db.go
@@ -53,9 +53,8 @@ type DatabaseI interface {
 }
 
 type compactionAction struct {
-	pathsToCompact     []string
-	totalRecords       uint64
-	canRemoveTombstone bool // if the compaction don't start from the first sstable we cannot remove tombstone
+	pathsToCompact []string
+	totalRecords   uint64
 }
 
 type memStoreFlushAction struct {
@@ -438,7 +437,8 @@ func CompactionFileThreshold(n int) ExtraOption {
 }
 
 // CompactionMaxSizeBytes tells whether an SSTable is considered for compaction.
-// SSTables over the given threshold will not be compacted any further. Default is 5GB in DefaultCompactionMaxSizeBytes
+// This is a best-effort implementation, depending on the write/delete pattern you may need to compact bigger tables.
+// Default is 5GB in DefaultCompactionMaxSizeBytes
 func CompactionMaxSizeBytes(n uint64) ExtraOption {
 	return func(args *ExtraOptions) {
 		args.compactionMaxSizeBytes = n

--- a/simpledb/db_test.go
+++ b/simpledb/db_test.go
@@ -187,7 +187,7 @@ func TestCompactionsFileThreshold(t *testing.T) {
 	defer cleanDatabaseFolder(t, db)
 	defer closeDatabase(t, db)
 
-	assert.Equal(t, 1337, db.compactionThreshold)
+	assert.Equal(t, 1337, db.compactionFileThreshold)
 }
 
 func assertGet(t *testing.T, db *DB, key string) {

--- a/simpledb/sstable_manager_test.go
+++ b/simpledb/sstable_manager_test.go
@@ -1,7 +1,6 @@
 package simpledb
 
 import (
-	sdbProto "github.com/thomasjungblut/go-sstables/simpledb/proto"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +12,8 @@ import (
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
 	"github.com/thomasjungblut/go-sstables/sstables/proto"
+
+	sdbProto "github.com/thomasjungblut/go-sstables/simpledb/proto"
 )
 
 func TestSSTableManagerAdditionHappyPath(t *testing.T) {

--- a/sstables/README.md
+++ b/sstables/README.md
@@ -100,7 +100,7 @@ You can get the full example from [examples/sstables.go](/_examples/sstables.go)
 
 One of the great features of SSTables is that you can merge them in linear time and in a sequential fashion, which needs only constant amount of space.  
 
-In this library, this can be easily composed here via full-table scanners and and a writer to output the resulting merged table: 
+In this library, this can be easily composed here via full-table scanners and a writer to output the resulting merged table: 
 
 ```go
 var iterators []sstables.SSTableMergeIteratorContext

--- a/sstables/super_sstable_reader.go
+++ b/sstables/super_sstable_reader.go
@@ -117,7 +117,14 @@ func ScanReduceLatestWins(key []byte, values [][]byte, context []int) ([]byte, [
 			maxCtxIndex = i
 		}
 	}
-	val := values[maxCtxIndex]
+
+	return key, values[maxCtxIndex]
+}
+
+// ScanReduceLatestWinsSkipTombstones is ScanReduceLatestWins but with additional checks on whether the value is tombstoned.
+// A value is tombstoned when the latest value is being empty, in which case this returns nil, nil.
+func ScanReduceLatestWinsSkipTombstones(key []byte, values [][]byte, context []int) ([]byte, []byte) {
+	key, val := ScanReduceLatestWins(key, values, context)
 	if len(val) == 0 {
 		return nil, nil
 	}

--- a/sstables/super_sstable_reader_test.go
+++ b/sstables/super_sstable_reader_test.go
@@ -293,6 +293,34 @@ func TestScanReduceFunc(t *testing.T) {
 	k, v = ScanReduceLatestWins(expectedKey, values, []int{0, 0, 0, 0})
 	assert.Equal(t, expectedKey, k)
 	assert.Equal(t, v, values[0])
+
+	// tombstone case, where the latest value is empty and returned as such
+	values = [][]byte{{}, {1}, {2}, {3}}
+	k, v = ScanReduceLatestWins(expectedKey, values, []int{1, 0, 0, 0})
+	assert.Equal(t, expectedKey, k)
+	assert.Equal(t, v, values[0])
+}
+
+func TestScanReduceLatestWinsWithTombstonesFunc(t *testing.T) {
+	expectedKey := []byte{0}
+	values := [][]byte{{0}, {1}, {2}, {3}}
+	k, v := ScanReduceLatestWinsSkipTombstones(expectedKey, values, []int{3, 2, 1, 0})
+	assert.Equal(t, expectedKey, k)
+	assert.Equal(t, v, values[0])
+
+	k, v = ScanReduceLatestWinsSkipTombstones(expectedKey, values, []int{0, 2, 1, 0})
+	assert.Equal(t, expectedKey, k)
+	assert.Equal(t, v, values[1])
+
+	k, v = ScanReduceLatestWinsSkipTombstones(expectedKey, values, []int{0, 0, 0, 0})
+	assert.Equal(t, expectedKey, k)
+	assert.Equal(t, v, values[0])
+
+	// tombstone case, where the latest value is empty and returned as nil
+	values = [][]byte{{}, {1}, {2}, {3}}
+	k, v = ScanReduceLatestWinsSkipTombstones(expectedKey, values, []int{1, 0, 0, 0})
+	assert.Nil(t, k)
+	assert.Nil(t, v)
 }
 
 func TestSuperStaggeredAndOverlappingFull(t *testing.T) {


### PR DESCRIPTION
This change updates the file selection process to include files regardless whether the sizes fit. This fixes a longer standing issue where smaller files between larger files (e.g. due to tombstone removal) can cause the data lineage to be corrupted.

This adds more tests and bumps the go version to 1.23.

fixes #36

cc @sebheitzmann  in case you want to test drive this a bit
