### PR TITLE
Compaction by tombstone ratio in simpledb

### DIFF
--- a/simpledb/compaction.go
+++ b/simpledb/compaction.go
@@ -55,7 +55,7 @@ func backgroundCompaction(db *DB) {
 }
 
 func executeCompaction(db *DB) (compactionMetadata *proto.CompactionMetadata, err error) {
-	compactionAction := db.sstableManager.candidateTablesForCompaction(db.compactedMaxSizeBytes)
+	compactionAction := db.sstableManager.candidateTablesForCompaction(db.compactedMaxSizeBytes, db.compactionRatio)
 	paths := compactionAction.pathsToCompact
 	numRecords := compactionAction.totalRecords
 	if len(paths) <= db.compactionFileThreshold {

--- a/simpledb/compaction_test.go
+++ b/simpledb/compaction_test.go
@@ -164,9 +164,8 @@ func TestCompactionWithTombstonesBeyondMaxSize(t *testing.T) {
 
 	compactionMeta, err := executeCompaction(db)
 	assert.Nil(t, err)
-	// TODO(thomas): this should also compact the 42 table, as it wastes a ton of space in tombstones
-	assert.Equal(t, "sstable_000000000000043", compactionMeta.ReplacementPath)
-	assert.Equal(t, []string{"sstable_000000000000043"}, compactionMeta.SstablePaths)
+	assert.Equal(t, "sstable_000000000000042", compactionMeta.ReplacementPath)
+	assert.Equal(t, []string{"sstable_000000000000042", "sstable_000000000000043"}, compactionMeta.SstablePaths)
 
 	err = db.sstableManager.reflectCompactionResult(compactionMeta)
 	assert.NoError(t, err)
@@ -175,8 +174,7 @@ func TestCompactionWithTombstonesBeyondMaxSize(t *testing.T) {
 	assert.Equal(t, "512", v)
 	// for cleanups
 	assert.Nil(t, db.sstableManager.currentReader.Close())
-	// TODO(thomas): ideally that table should only be 10
-	assert.Equal(t, 310, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
+	assert.Equal(t, 10, int(db.sstableManager.currentSSTable().MetaData().NumRecords))
 }
 
 func writeSSTableWithDataInDatabaseFolder(t *testing.T, db *DB, p string) {


### PR DESCRIPTION
This commit introduces a new compaction kind that will compact sstables when they have more than 20% of their keys tombstoned. This should save space when preserving them, as a later compaction can clean them up again. This trades-off available disk bandwidth and CPU with disk space.

cc @sebheitzmann I think I have to add a few more tests, but it seems to certainly fix the regression test from the previous PR.