### PR TITLE
refactor sstable index into a dedicated interface with a loader

### DIFF
--- a/_examples/sstables.go
+++ b/_examples/sstables.go
@@ -19,9 +19,7 @@ func main() {
 }
 
 func mainSimpleRead(path string) {
-	reader, err := sstables.NewSSTableReader(
-		sstables.ReadBasePath("/tmp/sstable_example/"),
-		sstables.ReadWithKeyComparator(skiplist.BytesComparator{}))
+	reader, err := sstables.NewSSTableReader(sstables.ReadBasePath("/tmp/sstable_example/"))
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}

--- a/benchmark/sstable_read_test.go
+++ b/benchmark/sstable_read_test.go
@@ -4,48 +4,90 @@ import (
 	"encoding/binary"
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomasjungblut/go-sstables/memstore"
 	"github.com/thomasjungblut/go-sstables/skiplist"
 	"github.com/thomasjungblut/go-sstables/sstables"
 	"os"
 	"testing"
+	"time"
 )
 
 // we're writing a gig worth of data and test how long it takes to read the index + all data
 func BenchmarkSSTableRead(b *testing.B) {
-	tmpDir, err := os.MkdirTemp("", "sstable_BenchRead")
-	assert.Nil(b, err)
-	defer func() { assert.Nil(b, os.RemoveAll(tmpDir)) }()
-
-	cmp := skiplist.BytesComparator{}
-	writer, err := sstables.NewSSTableStreamWriter(sstables.WriteBasePath(tmpDir), sstables.WithKeyComparator(cmp))
-	assert.Nil(b, err)
-	assert.Nil(b, writer.Open())
-
-	bytes := randomRecordOfSize(1024)
-	for i := 0; i < len(bytes)*1024; i++ {
-		k := make([]byte, 4)
-		binary.BigEndian.PutUint32(k, uint32(i))
-		assert.Nil(b, writer.WriteNext(k, bytes))
+	benchmarks := []struct {
+		name         string
+		memstoreSize int
+	}{
+		{"32mb", 1024 * 1024 * 32},
+		{"64mb", 1024 * 1024 * 64},
+		{"128mb", 1024 * 1024 * 128},
+		{"256mb", 1024 * 1024 * 256},
+		{"512mb", 1024 * 1024 * 512},
+		{"1024mb", 1024 * 1024 * 1024},
+		{"2048mb", 1024 * 1024 * 1024 * 2},
+		{"4096mb", 1024 * 1024 * 1024 * 4},
+		{"8192mb", 1024 * 1024 * 1024 * 8},
 	}
 
-	assert.Nil(b, writer.Close())
-	fullScanTable(b, tmpDir, cmp)
+	cmp := skiplist.BytesComparator{}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tmpDir, err := os.MkdirTemp("", "sstable_BenchRead_"+bm.name)
+			assert.Nil(b, err)
+			defer func() { assert.Nil(b, os.RemoveAll(tmpDir)) }()
+
+			mStore := memstore.NewMemStore()
+			bytes := randomRecordOfSize(1024)
+
+			i := 0
+			for mStore.EstimatedSizeInBytes() < uint64(bm.memstoreSize) {
+				k := make([]byte, 4)
+				binary.BigEndian.PutUint32(k, uint32(i))
+				assert.Nil(b, mStore.Add(k, bytes))
+				i++
+			}
+
+			assert.Nil(b, mStore.Flush(sstables.WriteBasePath(tmpDir), sstables.WithKeyComparator(cmp)))
+			defer func() {
+				assert.Nil(b, os.RemoveAll(tmpDir))
+			}()
+
+			b.ResetTimer()
+			fullScanTable(b, tmpDir, cmp)
+		})
+	}
 }
 
 func fullScanTable(b *testing.B, tmpDir string, cmp skiplist.Comparator[[]byte]) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		loadStart := time.Now()
 		reader, err := sstables.NewSSTableReader(sstables.ReadBasePath(tmpDir), sstables.ReadWithKeyComparator(cmp))
+		b.ReportMetric(float64(time.Now().Sub(loadStart).Milliseconds()), "load_time_ms")
+		b.ReportMetric(float64(time.Now().Sub(loadStart).Nanoseconds())/float64(reader.MetaData().NumRecords), "load_time_ns/record")
+
+		defer func() {
+			assert.Nil(b, reader.Close())
+		}()
+
 		assert.Nil(b, err)
+		scanStart := time.Now()
 		scanner, err := reader.Scan()
 		assert.Nil(b, err)
+		i := uint64(0)
 		for {
 			_, _, err := scanner.Next()
 			if errors.Is(err, sstables.Done) {
 				break
 			}
+			i++
+		}
+		if reader.MetaData().NumRecords != i {
+			b.Fail()
 		}
 		b.SetBytes(int64(reader.MetaData().TotalBytes))
-		assert.Nil(b, reader.Close())
+		b.ReportMetric(float64(time.Now().Sub(scanStart).Milliseconds()), "scan_time_ms")
+		b.ReportMetric(float64(time.Now().Sub(scanStart).Nanoseconds())/float64(i), "scan_time_ns/record")
+		b.ReportMetric(float64(i), "num_records")
 	}
 }

--- a/sstables/README.md
+++ b/sstables/README.md
@@ -62,13 +62,11 @@ if err != nil { log.Fatalf("error: %v", err) }
  
 ### Reading an SSTable
 
-Reading can be done by using having a path and the respective comparator. 
+Reading can be done by only passing a path to the sstable reader. 
 Below example will show what metadata is available, how to get values and check if they exist and how to do a range scan.
 
 ```go
-reader, err := sstables.NewSSTableReader(
-    sstables.ReadBasePath("/tmp/sstable_example/"),
-    sstables.ReadWithKeyComparator(skiplist.BytesComparator{}))
+reader, err := sstables.NewSSTableReader(sstables.ReadBasePath("/tmp/sstable_example/"))
 if err != nil { log.Fatalf("error: %v", err) }
 defer reader.Close()
 

--- a/sstables/sstable_index.go
+++ b/sstables/sstable_index.go
@@ -34,7 +34,7 @@ type SortedKeyIndex interface {
 
 type IndexLoader interface {
 	// Load is creating a SortedKeyIndex from the given path.
-	Load(path string) (SortedKeyIndex, error)
+	Load(path string, metadata *proto.MetaData) (SortedKeyIndex, error)
 }
 
 type SkipListIndexLoader struct {
@@ -42,7 +42,7 @@ type SkipListIndexLoader struct {
 	ReadBufferSize int
 }
 
-func (l *SkipListIndexLoader) Load(indexPath string) (_ SortedKeyIndex, err error) {
+func (l *SkipListIndexLoader) Load(indexPath string, _ *proto.MetaData) (_ SortedKeyIndex, err error) {
 	reader, err := rProto.NewReader(
 		rProto.ReaderPath(indexPath),
 		rProto.ReadBufferSizeBytes(l.ReadBufferSize),
@@ -61,9 +61,9 @@ func (l *SkipListIndexLoader) Load(indexPath string) (_ SortedKeyIndex, err erro
 	}()
 
 	indexMap := skiplist.NewSkipListMap[[]byte, IndexVal](l.KeyComparator)
+	record := &proto.IndexEntry{}
 
 	for {
-		record := &proto.IndexEntry{}
 		_, err := reader.ReadNext(record)
 		// io.EOF signals that no records are left to be read
 		if errors.Is(err, io.EOF) {

--- a/sstables/sstable_index.go
+++ b/sstables/sstable_index.go
@@ -1,0 +1,84 @@
+package sstables
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	rProto "github.com/thomasjungblut/go-sstables/recordio/proto"
+	"github.com/thomasjungblut/go-sstables/skiplist"
+	"github.com/thomasjungblut/go-sstables/sstables/proto"
+)
+
+type IndexVal struct {
+	Offset   uint64
+	Checksum uint64
+}
+
+type SortedKeyIndex interface {
+	// Contains returns true if the given key can be found in the index
+	Contains(key []byte) bool
+	// Get returns the IndexVal that compares equal to the key supplied or returns skiplist.NotFound if it does not exist.
+	Get(key []byte) (IndexVal, error)
+	// Iterator returns an iterator over the entire sorted sequence
+	Iterator() (skiplist.IteratorI[[]byte, IndexVal], error)
+	// IteratorStartingAt returns an iterator over the sorted sequence starting at the given key (inclusive if key is in the index).
+	// Using a key that is out of the sequence range will result in either an empty iterator or the full sequence.
+	IteratorStartingAt(key []byte) (skiplist.IteratorI[[]byte, IndexVal], error)
+	// IteratorBetween Returns an iterator over the sorted sequence starting at the given keyLower (inclusive if key is in the index)
+	// and until the given keyHigher was reached (inclusive if key is in the index).
+	// Using keys that are out of the sequence range will result in either an empty iterator or the full sequence.
+	// If keyHigher is lower than keyLower an error will be returned
+	IteratorBetween(keyLower []byte, keyHigher []byte) (skiplist.IteratorI[[]byte, IndexVal], error)
+}
+
+type IndexLoader interface {
+	// Load is creating a SortedKeyIndex from the given path.
+	Load(path string) (SortedKeyIndex, error)
+}
+
+type SkipListIndexLoader struct {
+	KeyComparator  skiplist.Comparator[[]byte]
+	ReadBufferSize int
+}
+
+func (l *SkipListIndexLoader) Load(indexPath string) (_ SortedKeyIndex, err error) {
+	reader, err := rProto.NewReader(
+		rProto.ReaderPath(indexPath),
+		rProto.ReadBufferSizeBytes(l.ReadBufferSize),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating index reader of sstable in '%s': %w", indexPath, err)
+	}
+
+	err = reader.Open()
+	if err != nil {
+		return nil, fmt.Errorf("error while opening index reader of sstable in '%s': %w", indexPath, err)
+	}
+
+	defer func() {
+		err = errors.Join(err, reader.Close())
+	}()
+
+	indexMap := skiplist.NewSkipListMap[[]byte, IndexVal](l.KeyComparator)
+
+	for {
+		record := &proto.IndexEntry{}
+		_, err := reader.ReadNext(record)
+		// io.EOF signals that no records are left to be read
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error while reading index records of sstable in '%s': %w", indexPath, err)
+		}
+
+		indexMap.Insert(record.Key, IndexVal{
+			Offset:   record.ValueOffset,
+			Checksum: record.Checksum,
+		})
+	}
+
+	return indexMap, nil
+}

--- a/sstables/sstable_iterator.go
+++ b/sstables/sstable_iterator.go
@@ -10,7 +10,7 @@ import (
 
 type SSTableIterator struct {
 	reader      *SSTableReader
-	keyIterator skiplist.IteratorI[[]byte, indexVal]
+	keyIterator skiplist.IteratorI[[]byte, IndexVal]
 }
 
 func (it *SSTableIterator) Next() ([]byte, []byte, error) {
@@ -35,7 +35,7 @@ func (it *SSTableIterator) Next() ([]byte, []byte, error) {
 // this is an optimized iterator that does a sequential read over the index+data files instead of a
 // sequential read on the index with a random access lookup on the data file via mmap
 type V0SSTableFullScanIterator struct {
-	keyIterator skiplist.IteratorI[[]byte, indexVal]
+	keyIterator skiplist.IteratorI[[]byte, IndexVal]
 	dataReader  rProto.ReaderI
 }
 
@@ -58,7 +58,7 @@ func (it *V0SSTableFullScanIterator) Next() ([]byte, []byte, error) {
 	return key, value.Value, nil
 }
 
-func newV0SStableFullScanIterator(keyIterator skiplist.IteratorI[[]byte, indexVal], dataReader rProto.ReaderI) (SSTableIteratorI, error) {
+func newV0SStableFullScanIterator(keyIterator skiplist.IteratorI[[]byte, IndexVal], dataReader rProto.ReaderI) (SSTableIteratorI, error) {
 	return &V0SSTableFullScanIterator{
 		keyIterator: keyIterator,
 		dataReader:  dataReader,
@@ -68,7 +68,7 @@ func newV0SStableFullScanIterator(keyIterator skiplist.IteratorI[[]byte, indexVa
 // SSTableFullScanIterator this is an optimized iterator that does a sequential read over the index+data files instead of a
 // sequential read on the index with a random access lookup on the data file via mmap
 type SSTableFullScanIterator struct {
-	keyIterator skiplist.IteratorI[[]byte, indexVal]
+	keyIterator skiplist.IteratorI[[]byte, IndexVal]
 	dataReader  recordio.ReaderI
 
 	skipHashCheck bool
@@ -98,20 +98,20 @@ func (it *SSTableFullScanIterator) Next() ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	if checksum != iVal.checksum {
+	if checksum != iVal.Checksum {
 		// this mismatch could come from default values, reading older formats
-		if iVal.checksum == 0 {
+		if iVal.Checksum == 0 {
 			return key, next, nil
 		}
 
-		return key, next, ChecksumError{checksum, iVal.checksum}
+		return key, next, ChecksumError{checksum, iVal.Checksum}
 	}
 
 	return key, next, err
 }
 
 func newSStableFullScanIterator(
-	keyIterator skiplist.IteratorI[[]byte, indexVal],
+	keyIterator skiplist.IteratorI[[]byte, IndexVal],
 	dataReader recordio.ReaderI,
 	skipHashCheck bool) (SSTableIteratorI, error) {
 	return &SSTableFullScanIterator{

--- a/sstables/sstable_reader.go
+++ b/sstables/sstable_reader.go
@@ -374,7 +374,7 @@ type SSTableReaderOptions struct {
 	readBufferSizeBytes int
 	indexLoader         IndexLoader
 
-	// TODO(thomas): this is a special case of the skiplist index, which should go into the loader implementation
+	// TODO(thomas): this is a special case of the skiplist index, which could go into the loader implementation
 	keyComparator skiplist.Comparator[[]byte]
 
 	skipHashCheckOnLoad bool
@@ -389,7 +389,7 @@ func ReadBasePath(p string) ReadOption {
 	}
 }
 
-// Deprecated: use a custom ReadIndexLoader and supply it to the SkipListIndexLoader
+// ReadWithKeyComparator sets a custom comparator for the index, defaults to skiplist.BytesComparator
 func ReadWithKeyComparator(cmp skiplist.Comparator[[]byte]) ReadOption {
 	return func(args *SSTableReaderOptions) {
 		args.keyComparator = cmp

--- a/sstables/sstable_reader.go
+++ b/sstables/sstable_reader.go
@@ -34,18 +34,12 @@ func (e ChecksumError) Error() string {
 	return fmt.Sprintf("Checksum mismatch: expected %x, got %x", e.expectedChecksum, e.checksum)
 }
 
-type indexVal struct {
-	offset   uint64
-	checksum uint64
-}
-
 type SSTableReader struct {
-	opts          *SSTableReaderOptions
-	bloomFilter   *bloomfilter.Filter
-	keyComparator skiplist.Comparator[[]byte]
-	// TODO(thomas): use a btree index on disk as an alternative?
-	// TODO(thomas): binary-search on disk could also work as an alternative, albeit much slower
-	index        skiplist.MapI[[]byte, indexVal] // key (as []byte) to a struct containing the uint64 value file offset
+	opts        *SSTableReaderOptions
+	bloomFilter *bloomfilter.Filter
+
+	// key (as []byte) to a struct containing the uint64 value file offset
+	index        SortedKeyIndex
 	v0DataReader rProto.ReadAtI
 	dataReader   recordio.ReadAtI
 	metaData     *proto.MetaData
@@ -54,7 +48,6 @@ type SSTableReader struct {
 
 func (reader *SSTableReader) Contains(key []byte) bool {
 	// short-cut for the bloom filter to tell whether it's not in the set (if available)
-	// TODO(thomas): this is unnecessary overhead, given the index is already a map lookup in memory
 	if reader.bloomFilter != nil {
 		fnvHash := fnv.New64()
 		_, _ = fnvHash.Write(key)
@@ -76,21 +69,21 @@ func (reader *SSTableReader) Get(key []byte) ([]byte, error) {
 	return reader.getValueAtOffset(iVal, reader.opts.skipHashCheckOnRead)
 }
 
-func (reader *SSTableReader) getValueAtOffset(iVal indexVal, skipHashCheck bool) (v []byte, err error) {
+func (reader *SSTableReader) getValueAtOffset(iVal IndexVal, skipHashCheck bool) (v []byte, err error) {
 	if reader.v0DataReader != nil {
 		value := &proto.DataEntry{}
-		_, err := reader.v0DataReader.ReadNextAt(value, iVal.offset)
+		_, err := reader.v0DataReader.ReadNextAt(value, iVal.Offset)
 		if err != nil && err != io.EOF {
 			return nil, fmt.Errorf("error in sstable '%s' while getting value at offset %d: %w",
-				reader.opts.basePath, iVal.offset, err)
+				reader.opts.basePath, iVal.Offset, err)
 		}
 
 		v = value.Value
 	} else {
-		v, err = reader.dataReader.ReadNextAt(iVal.offset)
+		v, err = reader.dataReader.ReadNextAt(iVal.Offset)
 		if err != nil && err != io.EOF {
 			return nil, fmt.Errorf("error in sstable '%s' while getting value at offset %d: %w",
-				reader.opts.basePath, iVal.offset, err)
+				reader.opts.basePath, iVal.Offset, err)
 		}
 	}
 
@@ -103,14 +96,14 @@ func (reader *SSTableReader) getValueAtOffset(iVal indexVal, skipHashCheck bool)
 		return nil, err
 	}
 
-	if valChecksum != iVal.checksum {
+	if valChecksum != iVal.Checksum {
 		// this mismatch could come from default values, reading older formats
-		if iVal.checksum == 0 {
+		if iVal.Checksum == 0 {
 			return v, nil
 		}
 
 		return v, fmt.Errorf("error in sstable '%s' while hashing value at offset [%d]: %w",
-			reader.opts.basePath, iVal.offset, ChecksumError{valChecksum, iVal.checksum})
+			reader.opts.basePath, iVal.Offset, ChecksumError{valChecksum, iVal.Checksum})
 	}
 
 	return v, nil
@@ -213,7 +206,10 @@ func (reader *SSTableReader) validateDataFile() error {
 		return err
 	}
 
-	indexReplacement := skiplist.NewSkipListMap[[]byte, indexVal](reader.opts.keyComparator)
+	skippedRecords := uint64(0)
+	// TODO(thomas): how do we deal with different implementations of the interface here?
+	// we could instead create a dedicated map for keys that are known to be corrupt and create a filtering on top
+	indexReplacement := skiplist.NewSkipListMap[[]byte, IndexVal](reader.opts.keyComparator)
 	for {
 		k, iv, err := iterator.Next()
 		if err != nil {
@@ -226,6 +222,7 @@ func (reader *SSTableReader) validateDataFile() error {
 
 		if _, err := reader.getValueAtOffset(iv, false); err != nil {
 			if errors.Is(err, ChecksumErr) && reader.opts.skipInvalidHashesOnLoad {
+				skippedRecords++
 				continue
 			}
 			return fmt.Errorf("error loading sstable '%s' at key [%v]: %w",
@@ -238,7 +235,7 @@ func (reader *SSTableReader) validateDataFile() error {
 	}
 
 	if reader.opts.skipInvalidHashesOnLoad {
-		reader.metaData.SkippedRecords = uint64(reader.index.Size() - indexReplacement.Size())
+		reader.metaData.SkippedRecords = skippedRecords
 		reader.index = indexReplacement
 	}
 
@@ -255,11 +252,10 @@ func checksumValue(value []byte) (uint64, error) {
 	return crc.Sum64(), nil
 }
 
-// NewSSTableReader creates a new reader. The sstable base path and comparator are mandatory:
-// > sstables.NewSSTableReader(sstables.ReadBasePath("some_path"), sstables.ReadWithKeyComparator(some_comp))
+// NewSSTableReader creates a new reader. The sstable base path is mandatory:
+// > sstables.NewSSTableReader(sstables.ReadBasePath("some_path"))
 // This function will check hashes and validity of the datafile matching the index file.
 func NewSSTableReader(readerOptions ...ReadOption) (SSTableReaderI, error) {
-
 	opts := &SSTableReaderOptions{
 		basePath: "",
 		// by default, we validate the integrity on loading and never checking when reading.
@@ -279,10 +275,17 @@ func NewSSTableReader(readerOptions ...ReadOption) (SSTableReaderI, error) {
 	}
 
 	if opts.keyComparator == nil {
-		return nil, errors.New("SSTableReader: no key comparator supplied")
+		opts.keyComparator = skiplist.BytesComparator{}
 	}
 
-	index, err := readIndex(filepath.Join(opts.basePath, IndexFileName), opts.keyComparator, opts.readBufferSizeBytes)
+	if opts.indexLoader == nil {
+		opts.indexLoader = &SkipListIndexLoader{
+			KeyComparator:  opts.keyComparator,
+			ReadBufferSize: opts.readBufferSizeBytes,
+		}
+	}
+
+	index, err := opts.indexLoader.Load(filepath.Join(opts.basePath, IndexFileName))
 	if err != nil {
 		return nil, fmt.Errorf("error while reading index of sstable in '%s': %w", opts.basePath, err)
 	}
@@ -339,47 +342,6 @@ func NewSSTableReader(readerOptions ...ReadOption) (SSTableReaderI, error) {
 	return reader, nil
 }
 
-func readIndex(indexPath string, keyComparator skiplist.Comparator[[]byte], readBufferSize int) (indexMap skiplist.MapI[[]byte, indexVal], err error) {
-	reader, err := rProto.NewReader(
-		rProto.ReaderPath(indexPath),
-		rProto.ReadBufferSizeBytes(readBufferSize),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error while creating index reader of sstable in '%s': %w", indexPath, err)
-	}
-
-	err = reader.Open()
-	if err != nil {
-		return nil, fmt.Errorf("error while opening index reader of sstable in '%s': %w", indexPath, err)
-	}
-
-	defer func() {
-		err = errors.Join(err, reader.Close())
-	}()
-
-	indexMap = skiplist.NewSkipListMap[[]byte, indexVal](keyComparator)
-
-	for {
-		record := &proto.IndexEntry{}
-		_, err := reader.ReadNext(record)
-		// io.EOF signals that no records are left to be read
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("error while reading index records of sstable in '%s': %w", indexPath, err)
-		}
-
-		indexMap.Insert(record.Key, indexVal{
-			offset:   record.ValueOffset,
-			checksum: record.Checksum,
-		})
-	}
-
-	return indexMap, nil
-}
-
 func readFilterIfExists(filterPath string) (*bloomfilter.Filter, error) {
 	if _, err := os.Stat(filterPath); os.IsNotExist(err) {
 		return nil, nil
@@ -426,12 +388,16 @@ func readMetaDataIfExists(metaPath string) (md *proto.MetaData, err error) {
 
 // SSTableReaderOptions contains both read/write options
 type SSTableReaderOptions struct {
-	basePath                string
-	keyComparator           skiplist.Comparator[[]byte]
+	basePath            string
+	readBufferSizeBytes int
+	indexLoader         IndexLoader
+
+	// TODO(thomas): this is a special case of the skiplist index, which should go into the loader implementation
+	keyComparator skiplist.Comparator[[]byte]
+
 	skipInvalidHashesOnLoad bool
 	skipHashCheckOnLoad     bool
 	skipHashCheckOnRead     bool
-	readBufferSizeBytes     int
 }
 
 type ReadOption func(*SSTableReaderOptions)
@@ -442,6 +408,7 @@ func ReadBasePath(p string) ReadOption {
 	}
 }
 
+// Deprecated: use a custom ReadIndexLoader and supply it to the SkipListIndexLoader
 func ReadWithKeyComparator(cmp skiplist.Comparator[[]byte]) ReadOption {
 	return func(args *SSTableReaderOptions) {
 		args.keyComparator = cmp
@@ -474,5 +441,12 @@ func EnableHashCheckOnReads() ReadOption {
 func ReadBufferSizeBytes(size int) ReadOption {
 	return func(args *SSTableReaderOptions) {
 		args.readBufferSizeBytes = size
+	}
+}
+
+// ReadIndexLoader allows to create a customized index from an index file.
+func ReadIndexLoader(il IndexLoader) ReadOption {
+	return func(args *SSTableReaderOptions) {
+		args.indexLoader = il
 	}
 }

--- a/sstables/sstable_reader.go
+++ b/sstables/sstable_reader.go
@@ -285,7 +285,12 @@ func NewSSTableReader(readerOptions ...ReadOption) (SSTableReaderI, error) {
 		}
 	}
 
-	index, err := opts.indexLoader.Load(filepath.Join(opts.basePath, IndexFileName))
+	metaData, err := readMetaDataIfExists(filepath.Join(opts.basePath, MetaFileName))
+	if err != nil {
+		return nil, fmt.Errorf("error while reading metadata of sstable in '%s': %w", opts.basePath, err)
+	}
+
+	index, err := opts.indexLoader.Load(filepath.Join(opts.basePath, IndexFileName), metaData)
 	if err != nil {
 		return nil, fmt.Errorf("error while reading index of sstable in '%s': %w", opts.basePath, err)
 	}
@@ -293,11 +298,6 @@ func NewSSTableReader(readerOptions ...ReadOption) (SSTableReaderI, error) {
 	filter, err := readFilterIfExists(filepath.Join(opts.basePath, BloomFileName))
 	if err != nil {
 		return nil, fmt.Errorf("error while reading filter of sstable in '%s': %w", opts.basePath, err)
-	}
-
-	metaData, err := readMetaDataIfExists(filepath.Join(opts.basePath, MetaFileName))
-	if err != nil {
-		return nil, fmt.Errorf("error while reading metadata of sstable in '%s': %w", opts.basePath, err)
 	}
 
 	reader := &SSTableReader{opts: opts, bloomFilter: filter, index: index, metaData: metaData}

--- a/sstables/sstable_reader_test.go
+++ b/sstables/sstable_reader_test.go
@@ -95,24 +95,6 @@ func TestCRCHashMismatchError(t *testing.T) {
 	require.Nil(t, reader)
 }
 
-func TestCRCHashMismatchErrorSkipRecord(t *testing.T) {
-	reader, err := NewSSTableReader(
-		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithCRCHashesMismatch"),
-		ReadWithKeyComparator(skiplist.BytesComparator{}),
-		SkipInvalidHashesOnLoad())
-	require.Nil(t, err)
-	defer closeReader(t, reader)
-
-	assert.Equal(t, 7, int(reader.MetaData().NumRecords))
-	assert.Equal(t, 1, int(reader.MetaData().SkippedRecords))
-	assert.Equal(t, 0, int(reader.MetaData().NullValues))
-	assert.Equal(t, []byte{0, 0, 0, 1}, reader.MetaData().MinKey)
-	assert.Equal(t, []byte{0, 0, 0, 7}, reader.MetaData().MaxKey)
-	// key 4 should be missing, as it has an invalid checksum
-	skipListMap := TEST_ONLY_NewSkipListMapWithElements([]int{1, 2, 3, 5, 6, 7})
-	assertContentMatchesSkipList(t, reader, skipListMap)
-}
-
 func TestCRCHashMismatchErrorSkipEntirelyReadChecks(t *testing.T) {
 	reader, err := NewSSTableReader(
 		ReadBasePath("test_files/SimpleWriteHappyPathSSTableWithCRCHashesMismatch"),
@@ -125,8 +107,6 @@ func TestCRCHashMismatchErrorSkipEntirelyReadChecks(t *testing.T) {
 
 	assert.Equal(t, 7, int(reader.MetaData().NumRecords))
 	assert.Equal(t, 0, int(reader.MetaData().NullValues))
-	// zero, as we're skipping the load-time validation
-	assert.Equal(t, 0, int(reader.MetaData().SkippedRecords))
 	assert.Equal(t, []byte{0, 0, 0, 1}, reader.MetaData().MinKey)
 	assert.Equal(t, []byte{0, 0, 0, 7}, reader.MetaData().MaxKey)
 


### PR DESCRIPTION
This is the first step to find a better and more performant solution for #47.

Key changes:
* new index interface
* new loader interface for an index
* `sstables.SkipInvalidHashesOnLoad` is now removed
* sstables comparator defaults to `skiplist.BytesComparator` so it doesn't have to be supplied anymore


