### PR TITLE
fix partial sstable writes

### DIFF
--- a/recordio/buffered_io.go
+++ b/recordio/buffered_io.go
@@ -17,7 +17,7 @@ func (d BufferedIOFactory) CreateNewReader(filePath string, bufSize int) (*os.Fi
 	return readFile, NewCountingByteReader(NewReaderBuf(readFile, block)), nil
 }
 
-func (d BufferedIOFactory) CreateNewWriter(filePath string, bufSize int) (*os.File, WriteCloserFlusher, error) {
+func (d BufferedIOFactory) CreateNewWriter(filePath string, bufSize int) (*os.File, WriteSeekerCloserFlusher, error) {
 	writeFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, nil, err

--- a/recordio/bufio_vendor_test.go
+++ b/recordio/bufio_vendor_test.go
@@ -3,6 +3,7 @@ package recordio
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"testing"
 )
 
@@ -13,6 +14,10 @@ type closingWriter struct {
 func (w *closingWriter) Write(p []byte) (n int, err error) {
 	copy(w.buf, p) // simply overwrite for testing purposes
 	return len(p), nil
+}
+
+func (w *closingWriter) Seek(offset int64, whence int) (int64, error) {
+	return offset, nil
 }
 
 func (*closingWriter) Close() error {
@@ -41,6 +46,24 @@ func TestCreateNewBufferCloseFlushes(t *testing.T) {
 	require.NoError(t, err)
 	// buffer should not been flushed so far
 	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0}, sink.buf)
+	require.NoError(t, wBuf.Close())
+	assert.Equal(t, []byte{13, 6, 91, 22, 0, 0}, sink.buf)
+}
+
+func TestSeekFlushes(t *testing.T) {
+	sink := &closingWriter{make([]byte, 6)}
+	wBuf := NewWriterBuf(sink, make([]byte, 4))
+	assert.Equal(t, 4, wBuf.Size())
+
+	_, err := wBuf.Write([]byte{13, 6, 91, 22})
+	require.NoError(t, err)
+	// buffer should not been flushed so far
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0}, sink.buf)
+
+	_, err = wBuf.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{13, 6, 91, 22, 0, 0}, sink.buf)
+
 	require.NoError(t, wBuf.Close())
 	assert.Equal(t, []byte{13, 6, 91, 22, 0, 0}, sink.buf)
 }

--- a/recordio/direct_io.go
+++ b/recordio/direct_io.go
@@ -21,7 +21,7 @@ func (d DirectIOFactory) CreateNewReader(filePath string, bufSize int) (*os.File
 	return readFile, NewCountingByteReader(NewReaderBuf(readFile, block)), nil
 }
 
-func (d DirectIOFactory) CreateNewWriter(filePath string, bufSize int) (*os.File, WriteCloserFlusher, error) {
+func (d DirectIOFactory) CreateNewWriter(filePath string, bufSize int) (*os.File, WriteSeekerCloserFlusher, error) {
 	writeFile, err := directio.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, nil, err

--- a/recordio/io_factory.go
+++ b/recordio/io_factory.go
@@ -6,5 +6,5 @@ import (
 
 type IOFactory interface {
 	CreateNewReader(filePath string, bufSize int) (*os.File, ByteReaderResetCount, error)
-	CreateNewWriter(filePath string, bufSize int) (*os.File, WriteCloserFlusher, error)
+	CreateNewWriter(filePath string, bufSize int) (*os.File, WriteSeekerCloserFlusher, error)
 }

--- a/recordio/recordio.go
+++ b/recordio/recordio.go
@@ -66,6 +66,10 @@ type WriterI interface {
 	Write(record []byte) (uint64, error)
 	// WriteSync appends a record of bytes and forces a disk sync, returns the current offset this item was written to
 	WriteSync(record []byte) (uint64, error)
+	// Seek will reset the current offset to the given offset. The offset is always
+	// denoted as a value from the start (origin) of the file at offset zero.
+	// An error will be returned when trying to seek into the file header or beyond the current size of the file.
+	Seek(offset uint64) error
 }
 
 type ReaderI interface {
@@ -86,7 +90,7 @@ type ReadAtI interface {
 
 type ReaderWriterCloserFactory interface {
 	CreateNewReader(filePath string, bufSize int) (*os.File, ByteReaderResetCount, error)
-	CreateNewWriter(filePath string, bufSize int) (*os.File, WriteCloserFlusher, error)
+	CreateNewWriter(filePath string, bufSize int) (*os.File, WriteSeekerCloserFlusher, error)
 }
 
 // NewCompressorForType returns an instance of the desired compressor defined by its identifier.


### PR DESCRIPTION
In some failure scenarios we might have inconsistent data and index files. This adds seeking support to recordio writers, which can be used to rewind partially written data records.
