### PR TITLE
Add a disk-based index

### DIFF
--- a/_examples/sstables.go
+++ b/_examples/sstables.go
@@ -28,7 +28,10 @@ func mainSimpleRead(path string) {
 	metadata := reader.MetaData()
 	log.Printf("reading table with %d records, minKey %d and maxKey %d", metadata.NumRecords, metadata.MinKey, metadata.MaxKey)
 
-	contains := reader.Contains([]byte{1})
+	contains, err := reader.Contains([]byte{1})
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
 	val, err := reader.Get([]byte{1})
 	if err != nil {
 		log.Fatalf("error: %v", err)

--- a/recordio/mmap_reader.go
+++ b/recordio/mmap_reader.go
@@ -60,8 +60,8 @@ func (r *MMapReader) SeekNext(offset uint64) (uint64, []byte, error) {
 	if !r.open || r.closed {
 		return 0, nil, fmt.Errorf("reader at '%s' was either not opened yet or is closed already", r.path)
 	}
-	if r.header.fileVersion < Version3 {
-		return 0, nil, fmt.Errorf("unsupported on files with version lower than v3")
+	if r.header.fileVersion < Version2 {
+		return 0, nil, fmt.Errorf("unsupported on files with version lower than v2")
 	}
 
 	headerBufPooled := r.bufferPool.Get(r.seekLen)
@@ -105,6 +105,8 @@ func (r *MMapReader) SeekNext(offset uint64) (uint64, []byte, error) {
 			// we found the marker starting at i, we try to read it
 			trialOffset := uint64(next) + uint64(i)
 			record, err := r.ReadNextAt(trialOffset)
+			// TODO(thomas): we also need to ensure that the value after that record is a valid header or EOF
+
 			if err == nil {
 				return trialOffset, record, nil
 			} else {

--- a/recordio/recordio.go
+++ b/recordio/recordio.go
@@ -24,6 +24,7 @@ const RecordHeaderSizeBytesV1V2 = 20
 // RecordHeaderV3MaxSizeBytes is the max buffer sizes to prevent PutUvarint to panic:
 // 10 byte magic number, 10 byte uncompressed size, 10 bytes for compressed size, 1 byte for nil = 31 bytes
 const RecordHeaderV3MaxSizeBytes = binary.MaxVarintLen64 + binary.MaxVarintLen64 + binary.MaxVarintLen64 + 1
+const RecordHeaderV3MinSizeBytes = 1 + 1 + 1 + 1
 
 // never reorder, always append
 const (

--- a/simpledb/sstable_manager_test.go
+++ b/simpledb/sstable_manager_test.go
@@ -223,8 +223,8 @@ func (m *MockSSTableReader) MetaData() *proto.MetaData {
 	return m.metadata
 }
 
-func (m *MockSSTableReader) Contains(key []byte) bool {
-	return false
+func (m *MockSSTableReader) Contains(key []byte) (bool, error) {
+	return false, nil
 }
 
 func (m *MockSSTableReader) Get(key []byte) ([]byte, error) {

--- a/sstables/README.md
+++ b/sstables/README.md
@@ -73,7 +73,8 @@ defer reader.Close()
 metadata := reader.MetaData()
 log.Printf("reading table with %d records, minKey %d and maxKey %d", metadata.NumRecords, metadata.MinKey, metadata.MaxKey)
 
-contains := reader.Contains([]byte{1})
+contains, err := reader.Contains([]byte{1})
+if err != nil { log.Fatalf("error: %v", err) }
 val, err := reader.Get([]byte{1})
 if err != nil { log.Fatalf("error: %v", err) }
 log.Printf("table contains value for key? %t = %d", contains, val)

--- a/sstables/disk_key_index.go
+++ b/sstables/disk_key_index.go
@@ -1,0 +1,179 @@
+package sstables
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/thomasjungblut/go-sstables/recordio"
+	rProto "github.com/thomasjungblut/go-sstables/recordio/proto"
+	"github.com/thomasjungblut/go-sstables/skiplist"
+	"github.com/thomasjungblut/go-sstables/sstables/proto"
+	"io"
+)
+
+// DiskKeyIndex is doing lookups on disk to find the value for a given key using binary search
+type DiskKeyIndex struct {
+	reader rProto.ReadAtI
+	// offsetCacheMaxSize defines how many entries are saved in the offsetCache
+	offsetCacheMaxSize int
+	// offsetCache caches the result of a given offset for the binary search
+	offsetCache map[uint64]*proto.IndexEntry
+}
+
+func (s *DiskKeyIndex) Close() error {
+	return s.reader.Close()
+}
+
+func (s *DiskKeyIndex) Open() error {
+	return s.reader.Open()
+}
+
+func (s *DiskKeyIndex) Contains(key []byte) (bool, error) {
+	_, _, exists, err := s.binarySearch(key)
+	return exists, err
+}
+
+func (s *DiskKeyIndex) Get(key []byte) (IndexVal, error) {
+	_, v, exists, err := s.binarySearch(key)
+	if err != nil {
+		return IndexVal{}, err
+	}
+	if !exists {
+		return IndexVal{}, skiplist.NotFound
+	}
+
+	return IndexVal{
+		Offset:   v.ValueOffset,
+		Checksum: v.Checksum,
+	}, nil
+}
+
+func (s *DiskKeyIndex) Iterator() (skiplist.IteratorI[[]byte, IndexVal], error) {
+	return s.newIterator(recordio.FileHeaderSizeBytes, s.reader.Size()), nil
+}
+
+func (s *DiskKeyIndex) IteratorStartingAt(key []byte) (skiplist.IteratorI[[]byte, IndexVal], error) {
+	offset, _, _, err := s.binarySearch(key)
+	if err != nil {
+		return nil, err
+	}
+	return s.newIterator(offset, s.reader.Size()), nil
+}
+
+func (s *DiskKeyIndex) IteratorBetween(keyLower []byte, keyHigher []byte) (skiplist.IteratorI[[]byte, IndexVal], error) {
+	if bytes.Compare(keyLower, keyHigher) > 0 {
+		return nil, errors.New("keyHigher is lower than keyLower")
+	}
+
+	startOffset, _, _, err := s.binarySearch(keyLower)
+	if err != nil {
+		return nil, err
+	}
+
+	endOffset, _, _, err := s.binarySearch(keyHigher)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.newIterator(startOffset, endOffset), nil
+}
+
+// adjusted version of sort.BinarySearchFunc, returning a file offset instead of an index
+func (s *DiskKeyIndex) binarySearch(target []byte) (uint64, *proto.IndexEntry, bool, error) {
+	n := s.reader.Size()
+	// Define cmp(x[-1], target) < 0 and cmp(x[n], target) >= 0 .
+	// Invariant: cmp(x[i - 1], target) < 0, cmp(x[j], target) >= 0.
+	i, j := uint64(0), n
+	for i < j {
+		h := (i + j) >> 1 // avoid overflow when computing h
+		// i ≤ h < j
+		at, err := s.findAt(h)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return n, nil, false, nil
+			}
+			return 0, nil, false, err
+		}
+		if bytes.Compare(at.Key, target) < 0 {
+			i = h + 1 // preserves cmp(x[i - 1], target) < 0
+		} else {
+			j = h // preserves cmp(x[j], target) >= 0
+		}
+	}
+	// i == j, cmp(x[i-1], target) < 0, and cmp(x[j], target) (= cmp(x[i], target)) >= 0  =>  answer is i.
+	at, err := s.findAt(i)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return n, nil, false, nil
+		}
+		return 0, nil, false, err
+	}
+	return i, at, i < n && bytes.Compare(at.Key, target) == 0, nil
+}
+
+func (s *DiskKeyIndex) findAt(off uint64) (*proto.IndexEntry, error) {
+	if val, ok := s.offsetCache[off]; ok {
+		return val, nil
+	}
+
+	record := &proto.IndexEntry{}
+	_, _, err := s.reader.SeekNext(record, off)
+	if len(s.offsetCache) < s.offsetCacheMaxSize {
+		s.offsetCache[off] = record
+	}
+
+	return record, err
+}
+
+func (s *DiskKeyIndex) newIterator(offset, endOffset uint64) *DiskKeyIndexIterator {
+	return &DiskKeyIndexIterator{
+		reader:        s.reader,
+		entry:         &proto.IndexEntry{},
+		currentOffset: offset,
+		endOffset:     endOffset,
+	}
+}
+
+type DiskKeyIndexIterator struct {
+	reader        rProto.ReadAtI
+	entry         *proto.IndexEntry
+	currentOffset uint64
+	endOffset     uint64
+}
+
+func (s *DiskKeyIndexIterator) Next() ([]byte, IndexVal, error) {
+	if s.currentOffset > s.endOffset {
+		return nil, IndexVal{}, skiplist.Done
+	}
+
+	offset, _, err := s.reader.SeekNext(s.entry, s.currentOffset)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, IndexVal{}, skiplist.Done
+		}
+		return nil, IndexVal{}, err
+	}
+
+	s.currentOffset = offset + 1
+	return s.entry.Key, IndexVal{
+		Offset:   s.entry.ValueOffset,
+		Checksum: s.entry.Checksum,
+	}, nil
+}
+
+type DiskIndexLoader struct {
+}
+
+func (l *DiskIndexLoader) Load(indexPath string, _ *proto.MetaData) (_ SortedKeyIndex, err error) {
+	reader, err := rProto.NewMMapProtoReaderWithPath(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating index reader of sstable in '%s': %w", indexPath, err)
+	}
+
+	idx := &DiskKeyIndex{
+		reader:             reader,
+		offsetCacheMaxSize: 128,
+		offsetCache:        make(map[uint64]*proto.IndexEntry),
+	}
+	return idx, nil
+}

--- a/sstables/empty_sstable_reader.go
+++ b/sstables/empty_sstable_reader.go
@@ -8,8 +8,8 @@ import (
 
 type EmptySStableReader struct{}
 
-func (EmptySStableReader) Contains(_ []byte) bool {
-	return false
+func (EmptySStableReader) Contains(_ []byte) (bool, error) {
+	return false, nil
 }
 
 func (EmptySStableReader) Get(_ []byte) ([]byte, error) {

--- a/sstables/empty_sstable_reader_test.go
+++ b/sstables/empty_sstable_reader_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestContains(t *testing.T) {
 	reader := EmptySStableReader{}
-	assert.False(t, reader.Contains([]byte{}), "contains returned true")
+	contains, err := reader.Contains([]byte{})
+	require.NoError(t, err)
+	assert.False(t, contains, "contains returned true")
 }
 
 func TestGet(t *testing.T) {

--- a/sstables/skiplist_index.go
+++ b/sstables/skiplist_index.go
@@ -1,0 +1,65 @@
+package sstables
+
+import (
+	"errors"
+	"fmt"
+	rProto "github.com/thomasjungblut/go-sstables/recordio/proto"
+	"github.com/thomasjungblut/go-sstables/skiplist"
+	"github.com/thomasjungblut/go-sstables/sstables/proto"
+	"io"
+)
+
+type SkipListIndex struct {
+	skiplist.MapI[[]byte, IndexVal]
+	NoOpOpenClose
+}
+
+func (s *SkipListIndex) Contains(key []byte) (bool, error) {
+	return s.MapI.Contains(key), nil
+}
+
+type SkipListIndexLoader struct {
+	KeyComparator  skiplist.Comparator[[]byte]
+	ReadBufferSize int
+}
+
+func (l *SkipListIndexLoader) Load(indexPath string, _ *proto.MetaData) (_ SortedKeyIndex, err error) {
+	reader, err := rProto.NewReader(
+		rProto.ReaderPath(indexPath),
+		rProto.ReadBufferSizeBytes(l.ReadBufferSize),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating index reader of sstable in '%s': %w", indexPath, err)
+	}
+
+	err = reader.Open()
+	if err != nil {
+		return nil, fmt.Errorf("error while opening index reader of sstable in '%s': %w", indexPath, err)
+	}
+
+	defer func() {
+		err = errors.Join(err, reader.Close())
+	}()
+
+	indexMap := skiplist.NewSkipListMap[[]byte, IndexVal](l.KeyComparator)
+	record := &proto.IndexEntry{}
+
+	for {
+		_, err := reader.ReadNext(record)
+		// io.EOF signals that no records are left to be read
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("error while reading index records of sstable in '%s': %w", indexPath, err)
+		}
+
+		indexMap.Insert(record.Key, IndexVal{
+			Offset:   record.ValueOffset,
+			Checksum: record.Checksum,
+		})
+	}
+
+	return &SkipListIndex{indexMap, NoOpOpenClose{}}, nil
+}

--- a/sstables/slice_key_index.go
+++ b/sstables/slice_key_index.go
@@ -18,6 +18,7 @@ type sliceKey struct {
 
 // SliceKeyIndex is keeping the entire index as a slice in memory and uses binary search to find the given keys.
 type SliceKeyIndex struct {
+	NoOpOpenClose
 	index []sliceKey
 }
 
@@ -36,9 +37,9 @@ func (s *SliceKeyIndex) Get(key []byte) (IndexVal, error) {
 	return IndexVal{}, skiplist.NotFound
 }
 
-func (s *SliceKeyIndex) Contains(key []byte) bool {
+func (s *SliceKeyIndex) Contains(key []byte) (bool, error) {
 	_, found := s.search(key)
-	return found
+	return found, nil
 }
 
 func (s *SliceKeyIndex) Iterator() (skiplist.IteratorI[[]byte, IndexVal], error) {
@@ -121,5 +122,5 @@ func (s *SliceKeyIndexLoader) Load(indexPath string, metadata *proto.MetaData) (
 		sx = append(sx, sliceKey{IndexVal{Offset: record.ValueOffset, Checksum: record.Checksum}, record.Key})
 	}
 
-	return &SliceKeyIndex{sx}, nil
+	return &SliceKeyIndex{NoOpOpenClose{}, sx}, nil
 }

--- a/sstables/sstable.go
+++ b/sstables/sstable.go
@@ -26,7 +26,7 @@ type SSTableIteratorI interface {
 
 type SSTableReaderI interface {
 	// Contains returns true when the given key exists, false otherwise
-	Contains(key []byte) bool
+	Contains(key []byte) (bool, error)
 	// Get returns the value associated with the given key, NotFound as the error otherwise
 	Get(key []byte) ([]byte, error)
 	// Scan returns an iterator over the whole sorted sequence. Scan uses a more optimized version that iterates the

--- a/sstables/sstable_reader_test.go
+++ b/sstables/sstable_reader_test.go
@@ -303,10 +303,19 @@ func TestScanRange(t *testing.T) {
 }
 
 func assertNegativeContains(t *testing.T, reader SSTableReaderI) {
-	assert.False(t, reader.Contains([]byte{}))
-	assert.False(t, reader.Contains([]byte{1}))
-	assert.False(t, reader.Contains([]byte{1, 2, 3}))
-	_, err := reader.Get([]byte{})
+	contains, err := reader.Contains([]byte{})
+	require.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = reader.Contains([]byte{1})
+	require.NoError(t, err)
+	assert.False(t, contains)
+
+	contains, err = reader.Contains([]byte{1, 2, 3})
+	require.NoError(t, err)
+	assert.False(t, contains)
+
+	_, err = reader.Get([]byte{})
 	assert.Equal(t, errors.New("key was not found"), err)
 	_, err = reader.Get([]byte{1})
 	assert.Equal(t, errors.New("key was not found"), err)


### PR DESCRIPTION
This adds a new disk-only index type that will binary search over the protobuf recordio on disk.