### PR TITLE
Add offset to return of SeekNext

### DIFF
--- a/recordio/proto/mmap_proto_reader.go
+++ b/recordio/proto/mmap_proto_reader.go
@@ -23,18 +23,18 @@ func (r *MMapProtoReader) ReadNextAt(record proto.Message, offset uint64) (proto
 	return record, nil
 }
 
-func (r *MMapProtoReader) SeekNext(record proto.Message, offset uint64) (proto.Message, error) {
-	bytes, err := r.ReadAtI.SeekNext(offset)
+func (r *MMapProtoReader) SeekNext(record proto.Message, offset uint64) (uint64, proto.Message, error) {
+	off, bytes, err := r.ReadAtI.SeekNext(offset)
 	if err != nil {
-		return nil, err
+		return off, nil, err
 	}
 
 	err = proto.Unmarshal(bytes, record)
 	if err != nil {
-		return nil, err
+		return off, nil, err
 	}
 
-	return record, nil
+	return off, record, nil
 }
 
 func NewMMapProtoReaderWithPath(path string) (ReadAtI, error) {

--- a/recordio/proto/recordio_proto.go
+++ b/recordio/proto/recordio_proto.go
@@ -22,7 +22,7 @@ type ReadAtI interface {
 	// SeekNext reads the next full record that comes after the provided offset. The main difference to ReadNextAt is
 	// that this function seeks to the next record marker, whereas ReadNextAt always needs to be pointed to the start of
 	// the record. This function returns any io related error, for example io.EOF, or a wrapped equivalent, when the end is reached.
-	SeekNext(record proto.Message, offset uint64) (proto.Message, error)
+	SeekNext(record proto.Message, offset uint64) (uint64, proto.Message, error)
 }
 
 type WriterI interface {

--- a/recordio/proto/recordio_proto_test.go
+++ b/recordio/proto/recordio_proto_test.go
@@ -152,13 +152,14 @@ func endToEndRandomReadWriteProtobuf(writer WriterI, t *testing.T, tmpFile *os.F
 	j := 0
 	for i := uint64(0); i < reader.Size(); i++ {
 		textLine := &test_files.TextLine{}
-		_, err := reader.SeekNext(textLine, i)
+		offset, _, err := reader.SeekNext(textLine, i)
 		if j == len(offsets) {
 			require.ErrorIs(t, err, io.EOF)
 		} else {
 			require.NoError(t, err)
 			expectedLine := lines[j]
 			require.Equal(t, expectedLine, textLine.Line)
+			require.Equal(t, offsets[j], offset)
 			if i >= offsets[j] {
 				j++
 			}

--- a/recordio/recordio.go
+++ b/recordio/recordio.go
@@ -93,8 +93,9 @@ type ReadAtI interface {
 
 	// SeekNext reads the next full record that comes after the provided offset. The main difference to ReadNextAt is
 	// that this function seeks to the next record marker, whereas ReadNextAt always needs to be pointed to the start of
-	// the record. This function returns any io related error, for example io.EOF, or a wrapped equivalent, when the end is reached.
-	SeekNext(offset uint64) ([]byte, error)
+	// the record.
+	// This function returns any io related error, for example io.EOF, or a wrapped equivalent, when the end is reached.
+	SeekNext(offset uint64) (uint64, []byte, error)
 }
 
 type ReaderWriterCloserFactory interface {


### PR DESCRIPTION
This allows to seek more effectively in iterations where we don't know how big the record is.