### PR TITLE
add simd for faster magic number searches

### DIFF
--- a/recordio/simd/magic_number_search.go
+++ b/recordio/simd/magic_number_search.go
@@ -1,0 +1,21 @@
+//go:build !cgo
+
+package simd
+
+func FindMagicNumber(data []byte, off int) int {
+	if len(data) < 3 {
+		return -1
+	}
+	if off >= len(data) || off < 0 {
+		return -1
+	}
+
+	for i := off; i < len(data)-2; i++ {
+		if data[i] == 145 &&
+			data[i+1] == 141 &&
+			data[i+2] == 76 {
+			return i
+		}
+	}
+	return -1
+}

--- a/recordio/simd/magic_number_search.go
+++ b/recordio/simd/magic_number_search.go
@@ -19,3 +19,32 @@ func FindMagicNumber(data []byte, off int) int {
 	}
 	return -1
 }
+
+// FindAllMagicNumbers finds all occurrences of the magic number pattern in the data,
+// starting from the given offset. Returns a slice of all offsets where the pattern was found.
+func FindAllMagicNumbers(data []byte, off int) []int {
+	if len(data) < 3 {
+		return nil
+	}
+	if off >= len(data) || off < 0 {
+		return nil
+	}
+
+	var results []int
+	pos := off
+
+	for {
+		next := FindMagicNumber(data, pos)
+		if next < 0 {
+			break
+		}
+		results = append(results, next)
+		// Start searching from the next position after this match
+		pos = next + 1
+		if pos >= len(data)-2 {
+			break
+		}
+	}
+
+	return results
+}

--- a/recordio/simd/magic_number_search_bench_test.go
+++ b/recordio/simd/magic_number_search_bench_test.go
@@ -1,0 +1,44 @@
+//go:build cgo
+
+package simd
+
+import (
+	"testing"
+)
+
+func BenchmarkFindMagicNumber(b *testing.B) {
+	// Create a large buffer with magic numbers scattered throughout
+	data := make([]byte, 1024*1024) // 1MB
+	pattern := []byte{145, 141, 76}
+
+	// Place magic numbers every 1000 bytes, but NOT at position 0
+	// Start at position 50000 to force processing significant data
+	for i := 50000; i < len(data)-3; i += 1000 {
+		data[i] = pattern[0]
+		data[i+1] = pattern[1]
+		data[i+2] = pattern[2]
+	}
+
+	// Place one at the end to ensure we find something
+	data[len(data)-3] = pattern[0]
+	data[len(data)-2] = pattern[1]
+	data[len(data)-1] = pattern[2]
+
+	for _, scenario := range allImplementationScenarios {
+		if !scenario.available() {
+			b.Skip("cpu instruction not available")
+		}
+
+		b.Run(scenario.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				result := scenario.fx(data, 0)
+				if result < 0 {
+					b.Fatal("should find magic number")
+				}
+			}
+		})
+	}
+}

--- a/recordio/simd/magic_number_search_bench_test.go
+++ b/recordio/simd/magic_number_search_bench_test.go
@@ -42,3 +42,42 @@ func BenchmarkFindMagicNumber(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkFindAllMagicNumbers(b *testing.B) {
+	// Create 1GB buffer with magic numbers every 50KB
+	const dataSize = 1024 * 1024 * 1024 // 1GB
+	const markerInterval = 50 * 1024    // 50KB
+
+	data := make([]byte, dataSize)
+	pattern := []byte{145, 141, 76}
+
+	// Place magic numbers every 50KB
+	for i := 0; i < len(data)-3; i += markerInterval {
+		data[i] = pattern[0]
+		data[i+1] = pattern[1]
+		data[i+2] = pattern[2]
+	}
+
+	// Place one at the end to ensure we find something
+	if len(data) >= 3 {
+		data[len(data)-3] = pattern[0]
+		data[len(data)-2] = pattern[1]
+		data[len(data)-1] = pattern[2]
+	}
+
+	// Calculate expected number of matches
+	// Markers placed at: 0, 50KB, 100KB, ..., n*50KB where n*50KB < dataSize-3
+	// Plus one at the end (dataSize-3)
+	expectedMatches := (dataSize-3)/markerInterval + 2 // floor division + loop markers + end marker
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.SetBytes(dataSize) // Report bandwidth in GB/s
+
+	for i := 0; i < b.N; i++ {
+		results := FindAllMagicNumbers(data, 0)
+		if len(results) != expectedMatches {
+			b.Fatalf("expected %d matches, got %d", expectedMatches, len(results))
+		}
+	}
+}

--- a/recordio/simd/magic_number_search_cgo.go
+++ b/recordio/simd/magic_number_search_cgo.go
@@ -91,3 +91,32 @@ func FindMagicNumber(data []byte, off int) int {
 
 	return cgo_find_magic_numbers_scalar(data, off)
 }
+
+// FindAllMagicNumbers finds all occurrences of the magic number pattern in the data,
+// starting from the given offset. Returns a slice of all offsets where the pattern was found.
+func FindAllMagicNumbers(data []byte, off int) []int {
+	if len(data) < 3 {
+		return nil
+	}
+	if off >= len(data) || off < 0 {
+		return nil
+	}
+
+	var results []int
+	pos := off
+
+	for {
+		next := FindMagicNumber(data, pos)
+		if next < 0 {
+			break
+		}
+		results = append(results, next)
+		// Start searching from the next position after this match
+		pos = next + 1
+		if pos >= len(data)-2 {
+			break
+		}
+	}
+
+	return results
+}

--- a/recordio/simd/magic_number_search_cgo.go
+++ b/recordio/simd/magic_number_search_cgo.go
@@ -1,0 +1,93 @@
+//go:build cgo
+
+package simd
+
+/*
+#cgo CFLAGS: -msse4.2 -mavx2 -mavx512f -mavx512bw
+#include "search.h"
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+var (
+	sse42Supported  bool
+	avx2Supported   bool
+	avx512Supported bool
+)
+
+func init() {
+	sse42Supported = int(C.cpu_supports_sse42()) == 1
+	avx2Supported = int(C.cpu_supports_avx2()) == 1
+	avx512Supported = int(C.cpu_supports_avx512()) == 1
+}
+
+func cgo_find_magic_numbers_avx512(data []byte, off int) int {
+	if len(data) < 3 {
+		return -1
+	}
+	if off >= len(data) || off < 0 {
+		return -1
+	}
+
+	ptr := (*C.uchar)(unsafe.Pointer(&data[0]))
+	offset := C.size_t(off)
+	length := C.size_t(len(data))
+	return int(C.find_magic_numbers_avx512(ptr, offset, length))
+}
+
+func cgo_find_magic_numbers_sse4(data []byte, off int) int {
+	if len(data) < 3 {
+		return -1
+	}
+	if off >= len(data) || off < 0 {
+		return -1
+	}
+
+	ptr := (*C.uchar)(unsafe.Pointer(&data[0]))
+	offset := C.size_t(off)
+	length := C.size_t(len(data))
+	return int(C.find_magic_numbers_sse4(ptr, offset, length))
+}
+
+func cgo_find_magic_numbers_avx2(data []byte, off int) int {
+	if len(data) < 3 {
+		return -1
+	}
+	if off >= len(data) || off < 0 {
+		return -1
+	}
+
+	ptr := (*C.uchar)(unsafe.Pointer(&data[0]))
+	offset := C.size_t(off)
+	length := C.size_t(len(data))
+	return int(C.find_magic_numbers_avx2(ptr, offset, length))
+}
+
+func cgo_find_magic_numbers_scalar(data []byte, off int) int {
+	if len(data) < 3 {
+		return -1
+	}
+	if off >= len(data) || off < 0 {
+		return -1
+	}
+
+	ptr := (*C.uchar)(unsafe.Pointer(&data[0]))
+	offset := C.size_t(off)
+	length := C.size_t(len(data))
+	return int(C.find_magic_numbers_scalar(ptr, offset, length))
+}
+
+func FindMagicNumber(data []byte, off int) int {
+	// Use best available implementation: AVX512 > AVX2 > SSE4 > Scalar
+	if avx512Supported {
+		return cgo_find_magic_numbers_avx512(data, off)
+	} else if avx2Supported {
+		return cgo_find_magic_numbers_avx2(data, off)
+	} else if sse42Supported {
+		return cgo_find_magic_numbers_sse4(data, off)
+	}
+
+	return cgo_find_magic_numbers_scalar(data, off)
+}

--- a/recordio/simd/magic_number_search_cgo_test.go
+++ b/recordio/simd/magic_number_search_cgo_test.go
@@ -1,0 +1,255 @@
+//go:build cgo
+
+package simd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var allImplementationScenarios = []struct {
+	name      string
+	fx        func([]byte, int) int
+	available func() bool
+}{
+	{"Scalar", cgo_find_magic_numbers_scalar, func() bool { return true }},
+	{"SSE4", cgo_find_magic_numbers_sse4, func() bool { return sse42Supported }},
+	{"AVX2", cgo_find_magic_numbers_avx2, func() bool { return avx2Supported }},
+	{"AVX512", cgo_find_magic_numbers_avx512, func() bool { return avx512Supported }},
+}
+
+func TestMagicNumberSearchByImplementationHappyPath(t *testing.T) {
+	for _, scenario := range allImplementationScenarios {
+		if !scenario.available() {
+			t.Skip("cpu instruction not available")
+		}
+		t.Run(scenario.name, func(t *testing.T) {
+			data := make([]byte, 10000)
+
+			firstMarker := 10000 - 300
+			data[firstMarker] = 145
+			data[firstMarker+1] = 141
+			data[firstMarker+2] = 76
+
+			secondMarker := 10000 - 3
+			data[secondMarker] = 145
+			data[secondMarker+1] = 141
+			data[secondMarker+2] = 76
+
+			// check the entire range
+			for i := 0; i < len(data); i++ {
+				actualResult := scenario.fx(data, i)
+				expectedResult := firstMarker
+				if i >= firstMarker+1 {
+					expectedResult = secondMarker
+				}
+
+				if i > secondMarker {
+					expectedResult = -1
+				}
+
+				require.Equalf(t, expectedResult, actualResult, "unexpected result at offset %d", i)
+			}
+		})
+	}
+}
+
+func TestMagicNumberSearchByImplementation(t *testing.T) {
+	for _, scenario := range allImplementationScenarios {
+		if !scenario.available() {
+			t.Skip("cpu instruction not available")
+		}
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Run("BoundarySizes", func(t *testing.T) {
+				// Test sizes around critical boundaries for SIMD implementations
+				for size := 9; size < 100; size++ {
+					t.Run(fmt.Sprintf("Size%d", size), func(t *testing.T) {
+						data := make([]byte, size)
+
+						// Place pattern at various positions
+						positions := []int{0, size - 3, size / 2}
+
+						for _, pos := range positions {
+							if pos >= 0 && pos+2 < size {
+								// Clear and set pattern
+								for i := range data {
+									data[i] = 0
+								}
+								data[pos] = 145
+								data[pos+1] = 141
+								data[pos+2] = 76
+
+								result := scenario.fx(data, 0)
+								require.Equalf(t, pos, result, "pattern at position %d in buffer of size %d", pos, size)
+							}
+						}
+					})
+				}
+			})
+
+			t.Run("LoopBoundaries", func(t *testing.T) {
+				// Test offsets that might cause issues with loop boundaries
+				// Test with pattern just before the loop would exit
+				for offset := 0; offset < 100; offset++ {
+					data := make([]byte, 100+offset)
+					data[offset+50] = 145
+					data[offset+51] = 141
+					data[offset+52] = 76
+
+					result := scenario.fx(data, offset)
+					require.Equalf(t, offset+50, result, "offset %d", offset)
+				}
+			})
+
+			t.Run("NearEndOfBuffer", func(t *testing.T) {
+				// Test cases where pattern is near the end, requiring fallback loop
+				for size := 30; size < 70; size++ {
+					data := make([]byte, size)
+					// Pattern at the very end
+					data[size-3] = 145
+					data[size-2] = 141
+					data[size-1] = 76
+
+					result := scenario.fx(data, 0)
+					require.Equalf(t, size-3, result, "size %d", size)
+
+					// Pattern just before end (should use fallback)
+					if size > 35 {
+						data[size-4] = 145
+						data[size-3] = 141
+						data[size-2] = 76
+						data[size-1] = 0
+
+						result = scenario.fx(data, 0)
+						require.Equalf(t, size-4, result, "size %d, pattern at size-4", size)
+					}
+				}
+			})
+
+			t.Run("MultipleIterations", func(t *testing.T) {
+				// Test with buffer large enough for multiple SIMD iterations
+				for _, size := range []int{60, 90, 120, 150} {
+					data := make([]byte, size)
+
+					// Place pattern at various positions across iterations
+					positions := []int{0, 30, 60, size - 3}
+
+					for _, pos := range positions {
+						if pos >= 0 && pos+2 < size {
+							// Clear and set pattern
+							for i := range data {
+								data[i] = 0
+							}
+							data[pos] = 145
+							data[pos+1] = 141
+							data[pos+2] = 76
+
+							result := scenario.fx(data, 0)
+							require.Equalf(t, pos, result, "size %d, pattern at %d", size, pos)
+						}
+					}
+				}
+			})
+
+			t.Run("OffsetWithinLoop", func(t *testing.T) {
+				// Test with non-zero starting offsets that fall within the SIMD loop
+				data := make([]byte, 100)
+				data[50] = 145
+				data[51] = 141
+				data[52] = 76
+
+				// Test various starting offsets
+				for offset := 0; offset < 50; offset++ {
+					result := scenario.fx(data, offset)
+					require.Equalf(t, 50, result, "offset %d", offset)
+				}
+			})
+
+			// AVX2 specific: loop condition is i + 32 <= end where end = len - 2
+			// So loop runs when i + 32 <= len - 2, i.e., i + 34 <= len
+			// Test exact boundary: len = 34 means loop runs once (i=0, 0+32=32 <= 34-2=32)
+			// Test just below: len = 33 means loop doesn't run (0+32=32 > 33-2=31)
+			t.Run("ExactLoopBoundary", func(t *testing.T) {
+				// Test size 33: loop should NOT run, fallback should handle it
+				data33 := make([]byte, 33)
+				data33[30] = 145
+				data33[31] = 141
+				data33[32] = 76
+				result := scenario.fx(data33, 0)
+				require.Equal(t, 30, result, "size 33, pattern at end")
+
+				// Test size 34: loop SHOULD run once
+				data34 := make([]byte, 34)
+				data34[31] = 145
+				data34[32] = 141
+				data34[33] = 76
+				result = scenario.fx(data34, 0)
+				require.Equal(t, 31, result, "size 34, pattern at end")
+
+				// Test size 35: loop should run once
+				data35 := make([]byte, 35)
+				data35[32] = 145
+				data35[33] = 141
+				data35[34] = 76
+				result = scenario.fx(data35, 0)
+				require.Equal(t, 32, result, "size 35, pattern at end")
+			})
+
+			// Test the transition point where loop stops and fallback takes over
+			t.Run("LoopToFallbackTransition", func(t *testing.T) {
+				// AVX2 loop advances by 30, so test around positions 30-34
+				for size := 32; size <= 70; size++ {
+					t.Run(fmt.Sprintf("Size%d", size), func(t *testing.T) {
+						// Test pattern at various positions near the boundary
+						testPositions := []int{}
+						if size >= 3 {
+							testPositions = append(testPositions, size-3) // at end
+						}
+						if size >= 35 {
+							testPositions = append(testPositions, 30) // in loop range
+							testPositions = append(testPositions, 31) // in loop range
+							testPositions = append(testPositions, 32) // boundary
+							testPositions = append(testPositions, 33) // boundary
+						}
+
+						for _, pos := range testPositions {
+							if pos >= 0 && pos+2 < size {
+								data := make([]byte, size)
+								for i := range data {
+									data[i] = 0
+								}
+								data[pos] = 145
+								data[pos+1] = 141
+								data[pos+2] = 76
+
+								result := scenario.fx(data, 0)
+								require.Equalf(t, pos, result, "size %d, pattern at position %d", size, pos)
+							}
+						}
+					})
+				}
+			})
+
+			// Test that we don't read past buffer boundaries
+			t.Run("BufferBoundarySafety", func(t *testing.T) {
+				// AVX2 loads 32 bytes at offsets i, i+1, i+2
+				// Maximum load is at i+2, loading 32 bytes = needs i+2+32 = i+34 <= len
+				// Test sizes that are exactly at the boundary
+				for size := 30; size <= 40; size++ {
+					data := make([]byte, size)
+					// Place pattern at the last valid position
+					if size >= 3 {
+						data[size-3] = 145
+						data[size-2] = 141
+						data[size-1] = 76
+
+						result := scenario.fx(data, 0)
+						require.Equalf(t, size-3, result, "size %d, pattern at last position", size)
+					}
+				}
+			})
+		})
+	}
+}

--- a/recordio/simd/magic_number_search_test.go
+++ b/recordio/simd/magic_number_search_test.go
@@ -33,6 +33,9 @@ func TestMagicNumberSearchHappyPath(t *testing.T) {
 
 		require.Equalf(t, expectedResult, actualResult, "unexpected result at offset %d", i)
 	}
+
+	foundMarkers := FindAllMagicNumbers(data, 0)
+	require.Equal(t, []int{firstMarker, secondMarker}, foundMarkers)
 }
 
 func TestMagicNumberSearchBoundary(t *testing.T) {

--- a/recordio/simd/magic_number_search_test.go
+++ b/recordio/simd/magic_number_search_test.go
@@ -1,0 +1,43 @@
+package simd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMagicNumberSearchHappyPath(t *testing.T) {
+	data := make([]byte, 10000)
+
+	firstMarker := 10000 - 300
+	data[firstMarker] = 145
+	data[firstMarker+1] = 141
+	data[firstMarker+2] = 76
+
+	secondMarker := 10000 - 3
+	data[secondMarker] = 145
+	data[secondMarker+1] = 141
+	data[secondMarker+2] = 76
+
+	// check the entire range
+	for i := 0; i < len(data); i++ {
+		actualResult := FindMagicNumber(data, i)
+		expectedResult := firstMarker
+		if i >= firstMarker+1 {
+			expectedResult = secondMarker
+		}
+
+		if i > secondMarker {
+			expectedResult = -1
+		}
+
+		require.Equalf(t, expectedResult, actualResult, "unexpected result at offset %d", i)
+	}
+}
+
+func TestMagicNumberSearchBoundary(t *testing.T) {
+	require.Equal(t, -1, FindMagicNumber([]byte{0, 1}, 0))
+	require.Equal(t, -1, FindMagicNumber([]byte{0, 1, 3, 4}, 3))
+	require.Equal(t, -1, FindMagicNumber([]byte{0, 1, 3, 4}, 4))
+	require.Equal(t, -1, FindMagicNumber([]byte{0, 1, 3, 4}, -1))
+}

--- a/recordio/simd/search.c
+++ b/recordio/simd/search.c
@@ -1,0 +1,210 @@
+#include "search.h"
+#include <immintrin.h>
+#include <cpuid.h>
+#include <stdint.h>
+#include <nmmintrin.h>  // SSE4.2
+
+static const unsigned char pattern[] = {145, 141, 76};
+
+// Scalar fallback implementation (no SIMD)
+int find_magic_numbers_scalar(const unsigned char* data, size_t off, size_t len) {
+    if (len < 3) return -1;
+    if (off >= len) return -1;
+
+    size_t end = len - 2;
+    for (size_t i = off; i < end; i++) {
+        if (data[i] == pattern[0] &&
+            data[i+1] == pattern[1] &&
+            data[i+2] == pattern[2]) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Returns 1 if AVX2 is available, 0 otherwise
+int cpu_supports_avx2() {
+#ifdef _WIN32
+    // Disable AVX2 on Windows due to GCC bug #54412 - stack alignment issues
+    // with AVX instructions on 64-bit Windows (MinGW)
+    return 0;
+#endif
+    unsigned int eax, ebx, ecx, edx;
+
+    // First, check if CPUID leaf 7 is supported
+    if (__get_cpuid_max(0, 0) < 7)
+        return 0;
+
+    // Call CPUID leaf 7, subleaf 0
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+
+    // Bit 5 of EBX in CPUID leaf 7 indicates AVX2 support
+    return (ebx & (1 << 5)) != 0;
+}
+
+// Returns 1 if SSE4.2 is available, 0 otherwise
+int cpu_supports_sse42() {
+    unsigned int eax, ebx, ecx, edx;
+    // Check if CPUID leaf 1 is supported
+    if (__get_cpuid_max(0, 0) < 1)
+        return 0;
+    
+    // Call CPUID leaf 1
+    __cpuid(1, eax, ebx, ecx, edx);
+    
+    // Bit 20 of ECX in CPUID leaf 1 indicates SSE4.2 support
+    return (ecx & (1 << 20)) != 0;
+}
+
+// Returns 1 if AVX512 is available, 0 otherwise
+int cpu_supports_avx512() {
+#ifdef _WIN32
+    // Disable AVX-512 on Windows due to GCC bug #54412 - stack alignment issues
+    // with AVX instructions on 64-bit Windows (MinGW)
+    return 0;
+#endif
+    unsigned int eax, ebx, ecx, edx;
+    if (__get_cpuid_max(0, 0) < 7) return 0;
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    return (ebx & (1 << 16)) != 0; // AVX-512F
+}
+
+// Optimized SSE4 implementation for 3-byte pattern search
+// Checks 14 positions per iteration by advancing 13 bytes at a time
+// Pattern bytes are broadcast once outside the loop for better performance
+int find_magic_numbers_sse4(const unsigned char* data, size_t off, size_t len) {
+    if (len < 3) return -1;
+    if (off >= len) return -1;
+    
+    size_t i = off;
+    size_t end = len - 2;
+
+    // Broadcast pattern bytes once outside the loop
+    __m128i p0 = _mm_set1_epi8(pattern[0]);
+    __m128i p1 = _mm_set1_epi8(pattern[1]);
+    __m128i p2 = _mm_set1_epi8(pattern[2]);
+
+    // Process 16 bytes per loop, checking 14 positions per iteration
+    // Advance by 14 bytes (16 - 3 + 1) to check all positions without gaps
+    for (; i + 16 <= end; i += 14) {
+        __m128i d0 = _mm_loadu_si128((const __m128i*)(data + i));
+        __m128i d1 = _mm_loadu_si128((const __m128i*)(data + i + 1));
+        __m128i d2 = _mm_loadu_si128((const __m128i*)(data + i + 2));
+
+        __m128i m0 = _mm_cmpeq_epi8(d0, p0);
+        __m128i m1 = _mm_cmpeq_epi8(d1, p1);
+        __m128i m2 = _mm_cmpeq_epi8(d2, p2);
+
+        __m128i mask = _mm_and_si128(_mm_and_si128(m0, m1), m2);
+        int matchmask = _mm_movemask_epi8(mask);
+
+        if (matchmask) {
+            // return the first match index
+            return i + __builtin_ctz(matchmask);
+        }
+    }
+
+    // Fallback naive scan for remaining bytes
+    for (; i < end; i++) {
+        if (data[i] == pattern[0] &&
+            data[i+1] == pattern[1] &&
+            data[i+2] == pattern[2]) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+// Optimized AVX2 implementation for 3-byte pattern search
+// Checks 30 positions per iteration by advancing 29 bytes at a time
+// Pattern bytes are broadcast once outside the loop for better performance
+int find_magic_numbers_avx2(const unsigned char* data, size_t off, size_t len) {
+    if (len < 3) return -1;
+    if (off >= len) return -1;
+
+    size_t i = off;
+    size_t end = len - 2;
+
+    // Broadcast pattern bytes once outside the loop (compiler may optimize this anyway)
+    __m256i p0 = _mm256_set1_epi8(pattern[0]);
+    __m256i p1 = _mm256_set1_epi8(pattern[1]);
+    __m256i p2 = _mm256_set1_epi8(pattern[2]);
+
+    // Process 32 bytes per loop, checking 30 positions per iteration
+    // Advance by 30 bytes (32 - 3 + 1) to check all positions without gaps
+    for (; i + 32 <= end; i += 30) {
+        __m256i d0 = _mm256_loadu_si256((const __m256i*)(data + i));
+        __m256i d1 = _mm256_loadu_si256((const __m256i*)(data + i + 1));
+        __m256i d2 = _mm256_loadu_si256((const __m256i*)(data + i + 2));
+
+        __m256i m0 = _mm256_cmpeq_epi8(d0, p0);
+        __m256i m1 = _mm256_cmpeq_epi8(d1, p1);
+        __m256i m2 = _mm256_cmpeq_epi8(d2, p2);
+
+        __m256i mask = _mm256_and_si256(_mm256_and_si256(m0, m1), m2);
+        int matchmask = _mm256_movemask_epi8(mask);
+
+        if (matchmask) {
+            // return the first match index
+            return i + __builtin_ctz(matchmask);
+        }
+    }
+
+    // Fallback naive scan for remaining bytes
+    for (; i < end; i++) {
+        if (data[i] == pattern[0] &&
+            data[i+1] == pattern[1] &&
+            data[i+2] == pattern[2]) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+
+// Optimized AVX512 implementation for 3-byte pattern search
+// Checks 62 positions per iteration by advancing 61 bytes at a time
+// Pattern bytes are broadcast once outside the loop for better performance
+int find_magic_numbers_avx512(const unsigned char* data, size_t off, size_t len) {
+    if (len < 3) return -1;
+    if (off >= len) return -1;
+
+    size_t i = off;
+    size_t end = len - 2;
+
+    // Broadcast pattern bytes once outside the loop
+    __m512i p0 = _mm512_set1_epi8(pattern[0]);
+    __m512i p1 = _mm512_set1_epi8(pattern[1]);
+    __m512i p2 = _mm512_set1_epi8(pattern[2]);
+
+    // Process 64 bytes per loop, checking 62 positions per iteration
+    // Advance by 62 bytes (64 - 3 + 1) to check all positions without gaps
+    for (; i + 64 <= end; i += 62) {
+        __m512i d0 = _mm512_loadu_si512((const void*)(data + i));
+        __m512i d1 = _mm512_loadu_si512((const void*)(data + i + 1));
+        __m512i d2 = _mm512_loadu_si512((const void*)(data + i + 2));
+
+        // AVX512 uses mask registers which are more efficient
+        __mmask64 m0 = _mm512_cmpeq_epi8_mask(d0, p0);
+        __mmask64 m1 = _mm512_cmpeq_epi8_mask(d1, p1);
+        __mmask64 m2 = _mm512_cmpeq_epi8_mask(d2, p2);
+
+        __mmask64 mask = m0 & m1 & m2;
+        if (mask) {
+            return i + __builtin_ctzll(mask);
+        }
+    }
+
+    // Fallback naive scan for remaining bytes
+    for (; i < end; i++) {
+        if (data[i] == pattern[0] &&
+            data[i+1] == pattern[1] &&
+            data[i+2] == pattern[2]) {
+            return i;
+        }
+    }
+
+    return -1;
+}

--- a/recordio/simd/search.h
+++ b/recordio/simd/search.h
@@ -1,0 +1,20 @@
+#ifndef SEARCH_H
+#define SEARCH_H
+
+#include <stddef.h>
+
+int cpu_supports_sse42();
+
+int cpu_supports_avx2();
+
+int cpu_supports_avx512();
+
+int find_magic_numbers_sse4(const unsigned char* data, size_t off, size_t len);
+
+int find_magic_numbers_avx2(const unsigned char* data, size_t off, size_t len);
+
+int find_magic_numbers_avx512(const unsigned char* data, size_t off, size_t len);
+
+int find_magic_numbers_scalar(const unsigned char* data, size_t off, size_t len);
+
+#endif


### PR DESCRIPTION
That PR adds a magic number search based on AVX2. This reduces the sstable disk index search time from:

> BenchmarkSSTableRandomReadByIndexTypes/disk-20             	   44634	     26629 ns/op

to

> BenchmarkSSTableRandomReadByIndexTypes/disk-20             	   56840	     20364 ns/op

Not an insane improvement, but I think we can use that to very quickly read the recordio file to determine the index offsets. Which in turn allows to binary search/map lookup without additional seeking.

The SSE4.2 version can read 10-12gb/s to find the magic numbers (up from 3gb/s with simple looping), so this allows us to compute the lookup table very quickly.
